### PR TITLE
Improve credential labels in issuance and my creds

### DIFF
--- a/src/renderer/components/CredentialIssuance/IssuedCredList.vue
+++ b/src/renderer/components/CredentialIssuance/IssuedCredList.vue
@@ -15,7 +15,7 @@
       <ul class="list">
         <el-collapse-item
           v-for="issued_credential in credentials"
-          v-bind:title="issued_credential.connection_their_label + ' ' + issued_credential.cred_def_id"
+          v-bind:title="credential_title(issued_credential)"
           :name="issued_credential.credential_exchange_id"
           :key="issued_credential.credential_exchange_id">
           <el-row>
@@ -88,10 +88,12 @@
 
 <script>
 import VueJsonPretty from 'vue-json-pretty';
+import share from '@/share.js';
 
 export default {
   name: 'issued-cred-list',
   props: ['title', 'list', 'connections', 'cred_defs'],
+  mixins: [share({use: ['id_to_connection']})],
   components: {
     VueJsonPretty,
   },
@@ -111,17 +113,14 @@ export default {
   },
   computed: {
     credentials: function() {
-        let joinedCredentialsConnections = this.list.map((item) => {
-          var index = this.connections.map(function(x) {return x.connection_id; }).indexOf(item.connection_id);
-          var objectFound = this.connections[index];
-          if (index >= 0) {
-            item.connection_their_label = this.connections[index].their_label
-          }else{
-            item.connection_their_label = "deleted connetion"
-          }
+      return this.list.map(item => {
+        if (item.connection_id in this.id_to_connection) {
+          item.connection = this.id_to_connection[item.connection_id];
+        } else {
+          item.connection = null;
+        }
         return item;
-        },{})
-        return joinedCredentialsConnections;
+      });
     },
   },
   methods: {
@@ -164,6 +163,16 @@ export default {
         });
       });
     },
+    credential_title: function(cred) {
+      let split = cred.schema_id.split(':');
+      let connection_name = '';
+      if (!cred.connection) {
+        connection_name = '[deleted]';
+      } else {
+        connection_name = cred.connection.their_label;
+      }
+      return `${split[2]} v${split[3]} issued to ${connection_name}`;
+    }
   }
 }
 </script>

--- a/src/renderer/components/MyCredentials/index.vue
+++ b/src/renderer/components/MyCredentials/index.vue
@@ -8,7 +8,7 @@
     <my-credentials-list
       title="Credentials"
       editable="false"
-      v-bind:credentials="holder_credentials"
+      v-bind:list="holder_credentials"
       v-bind:cred_defs="proposal_cred_defs"
       v-bind:connections="active_connections"
       @cred-refresh="fetch_holder_credentials"
@@ -98,6 +98,9 @@ export default {
       };
       this.send_message(query_msg);
     }
+  },
+  created: function() {
+    this.fetch_holder_credentials();
   }
 }
 </script>


### PR DESCRIPTION
Now shows "schema_name v0.1 issued to Bob" and "schema_name v0.1 received from alice" instead of unrecognizable UUIDs.

Signed-off-by: Daniel Bluhm <daniel.bluhm@sovrin.org>