### PR TITLE
Consider cxns with state "respose" to be "active"

### DIFF
--- a/src/renderer/components/Connections/index.vue
+++ b/src/renderer/components/Connections/index.vue
@@ -62,7 +62,12 @@ export const shared = {
   computed: {
     active_connections: function() {
         return Object.values(this.connections).filter(
-            conn => "state" in conn && conn.state === "active"
+          conn => {
+            if (!("state" in conn)) {
+              return false;
+            }
+            return conn.state === "active" || conn.state === "response"
+          }
         );
     },
     id_to_connection: function(connection_id) {


### PR DESCRIPTION
This should hopefully help with connections with StreetCred.
cc @ken-ebert

Signed-off-by: Daniel Bluhm <daniel.bluhm@sovrin.org>