### PR TITLE
Admin Holder Protocol documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ help:
 docs: $(generated)
 
 clean:
-	rm -r $(dir $(generated))
+	-rm -r $(dir $(generated))
 
 $(generated): $(readmes)
 	@./scripts/generate_doc_folders.sh $(readmes)

--- a/docs/admin-holder/0.1/README.md
+++ b/docs/admin-holder/0.1/README.md
@@ -1,67 +1,609 @@
-Holder Admin Protocol
-=====================
+# Holder Admin Protocol
 
 ## Overview
 
-**Protocol URI:** `https://github.com/hyperledger/aries-toolbox/tree/master/docs/admin-holder/0.1`
+**Protocol URI:** `did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1`
 
-The holder admin protocol is used to manage credentials received by the
-connected agent.
+Define messages for credential holder admin protocols.
 
-### Protocol Messages
-- [credentials-get-list](#credentials-get-list)
-- [credentials-list](#credentials-list)
-- [credentials-send-proposal](#credentials-send-proposal)
-- [credentials-proposal-sent](#credentials-proposal-sent)
-- [credentials-offer-received](#credentials-offer-received)
-- [credentials-accept-offer](#credentials-accept)
-- [presentations-get-list](#presentations-get-list)
-- [presentations-list](#presentations-list)
-- [presentations-send-proposal](#presentations-send-proposal)
-- [presentations-proposal-sent](#presentations-proposal-sent)
-- [presentations-request-received](#presentations-request-received)
-- [presentations-accept-request](#presentations-accept-request)
+### Protocol Messages- [credential-exchange](#credential-exchange)- [credentials-get-list](#credentials-get-list)- [credentials-list](#credentials-list)- [credential-offer-accept](#credential-offer-accept)- [credential-offer-received](#credential-offer-received)- [credential-request-sent](#credential-request-sent)- [presentation-exchange](#presentation-exchange)- [presentations-get-list](#presentations-get-list)- [presentations-list](#presentations-list)- [presentation-request-approve](#presentation-request-approve)- [send-credential-proposal](#send-credential-proposal)- [send-presentation-proposal](#send-presentation-proposal)## Message Definitions### credential-exchange
 
-
-## Common Elements
-
-### Credential Representation
+Credential exchange message.
 
 Example:
 
-```jsonc
+```json
 {
-	"issuer_did": "<issuer did>",
-	"issuer_connection_id": "<connection id>",
-	"name": "<credential name>",
-	"comment": "comment about the credential"
-	"received_at": "<datetime>",
-	"attributes": [
-		{
-			"name": "attribute_name",
-			"value": "value"
-		},
-		...
-	],
-	"metadata": {
-		"schema_id": "<schema id>",
-		"cred_def_id": "<cred def id>"
-	},
-	"raw_repr": { ... }
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-exchange",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "state": "credential_acked",
+  "created_at": "2021-03-04 22:36:28Z",
+  "updated_at": "2021-03-04 22:36:28Z",
+  "trace": null,
+  "credential_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "parent_thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "initiator": "self",
+  "role": "issuer",
+  "credential_definition_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+  "schema_id": "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+  "credential_proposal_dict": null,
+  "credential_offer_dict": null,
+  "credential_offer": null,
+  "credential_request": null,
+  "credential_request_metadata": null,
+  "credential_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "raw_credential": null,
+  "credential": null,
+  "auto_offer": false,
+  "auto_issue": false,
+  "auto_remove": false,
+  "error_msg": "credential definition identifier is not set in proposal",
+  "revoc_reg_id": null,
+  "revocation_id": null
 }
 ```
 
+#### Fields
 
-## Message Definitions
+`@type` (String): Message type
 
-> _**Note:**_ Some attributes are shortened or omitted from the examples in this
-> section, such as the `@id` and `@type` attributes. The omission is for brevity
-> and clarity of the example and it should be assumed that each example message
-> contains all attributes required to be processed by the receiving agent.
+`@id` (String; Optional): Message identifier
 
-### credentials-get-list
-Retrieve a list of credentials held by the connected agent.
+`state` (String; Optional): Issue-credential exchange state
 
-### credentials-list
-Response to `credentials-get-list` containing list of credentials held by the
-connected agent.
+`created_at` (String; Optional): Time of record creation
+
+`updated_at` (String; Optional): Time of last record update
+
+`trace` (Boolean; Optional): Record trace information, based on agent configuration
+
+`credential_exchange_id` (String; Optional): Credential exchange identifier
+
+`connection_id` (String; Optional): Connection identifier
+
+`thread_id` (String; Optional): Thread identifier
+
+`parent_thread_id` (String; Optional): Parent thread identifier
+
+`initiator` (String; Optional): Issue-credential exchange initiator: self or external
+
+`role` (String; Optional): Issue-credential exchange role: holder or issuer
+
+`credential_definition_id` (String; Optional): Credential definition identifier
+
+`schema_id` (String; Optional): Schema identifier
+
+`credential_proposal_dict` (Dict; Optional): Serialized credential proposal message
+
+`credential_offer_dict` (Dict; Optional): Serialized credential offer message
+
+`credential_offer` (Dict; Optional): (Indy) credential offer
+
+`credential_request` (Dict; Optional): (Indy) credential request
+
+`credential_request_metadata` (Dict; Optional): (Indy) credential request metadata
+
+`credential_id` (String; Optional): Credential identifier
+
+`raw_credential` (Dict; Optional): Credential as received, prior to storage in holder wallet
+
+`credential` (Dict; Optional): Credential as stored
+
+`auto_offer` (Boolean; Optional): Holder choice to accept offer in this credential exchange
+
+`auto_issue` (Boolean; Optional): Issuer choice to issue to request in this credential exchange
+
+`auto_remove` (Boolean; Optional): Issuer choice to remove this credential exchange record when complete
+
+`error_msg` (String; Optional): Error message
+
+`revoc_reg_id` (String; Optional): Revocation registry identifier
+
+`revocation_id` (String; Optional): Credential identifier within revocation registry### credentials-get-list
+
+Credential list retrieval message.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credentials-get-list",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "~paginate": {
+    "limit": null,
+    "offset": null
+  }
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`~paginate` (Nested; Optional): Fields of paginate decorator.### credentials-list
+
+Credential list message.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credentials-list",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "results": null,
+  "~page": {
+    "count": null,
+    "offset": null,
+    "remaining": null
+  }
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`results` (List; Optional): 
+
+`~page` (Nested; Optional): Fields of page decorator.### credential-offer-accept
+
+Credential offer accept message.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-offer-accept",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "credential_exchange_id": null
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`credential_exchange_id` (String): ### credential-offer-received
+
+Credential offer received message.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-offer-received",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "state": "credential_acked",
+  "created_at": "2021-03-04 22:36:28Z",
+  "updated_at": "2021-03-04 22:36:28Z",
+  "trace": null,
+  "credential_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "parent_thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "initiator": "self",
+  "role": "issuer",
+  "credential_definition_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+  "schema_id": "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+  "credential_proposal_dict": null,
+  "credential_offer_dict": null,
+  "credential_offer": null,
+  "credential_request": null,
+  "credential_request_metadata": null,
+  "credential_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "raw_credential": null,
+  "credential": null,
+  "auto_offer": false,
+  "auto_issue": false,
+  "auto_remove": false,
+  "error_msg": "credential definition identifier is not set in proposal",
+  "revoc_reg_id": null,
+  "revocation_id": null
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`state` (String; Optional): Issue-credential exchange state
+
+`created_at` (String; Optional): Time of record creation
+
+`updated_at` (String; Optional): Time of last record update
+
+`trace` (Boolean; Optional): Record trace information, based on agent configuration
+
+`credential_exchange_id` (String; Optional): Credential exchange identifier
+
+`connection_id` (String; Optional): Connection identifier
+
+`thread_id` (String; Optional): Thread identifier
+
+`parent_thread_id` (String; Optional): Parent thread identifier
+
+`initiator` (String; Optional): Issue-credential exchange initiator: self or external
+
+`role` (String; Optional): Issue-credential exchange role: holder or issuer
+
+`credential_definition_id` (String; Optional): Credential definition identifier
+
+`schema_id` (String; Optional): Schema identifier
+
+`credential_proposal_dict` (Dict; Optional): Serialized credential proposal message
+
+`credential_offer_dict` (Dict; Optional): Serialized credential offer message
+
+`credential_offer` (Dict; Optional): (Indy) credential offer
+
+`credential_request` (Dict; Optional): (Indy) credential request
+
+`credential_request_metadata` (Dict; Optional): (Indy) credential request metadata
+
+`credential_id` (String; Optional): Credential identifier
+
+`raw_credential` (Dict; Optional): Credential as received, prior to storage in holder wallet
+
+`credential` (Dict; Optional): Credential as stored
+
+`auto_offer` (Boolean; Optional): Holder choice to accept offer in this credential exchange
+
+`auto_issue` (Boolean; Optional): Issuer choice to issue to request in this credential exchange
+
+`auto_remove` (Boolean; Optional): Issuer choice to remove this credential exchange record when complete
+
+`error_msg` (String; Optional): Error message
+
+`revoc_reg_id` (String; Optional): Revocation registry identifier
+
+`revocation_id` (String; Optional): Credential identifier within revocation registry### credential-request-sent
+
+Credential offer acceptance received and credential request sent.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-request-sent",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "state": "credential_acked",
+  "created_at": "2021-03-04 22:36:28Z",
+  "updated_at": "2021-03-04 22:36:28Z",
+  "trace": null,
+  "credential_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "parent_thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "initiator": "self",
+  "role": "issuer",
+  "credential_definition_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+  "schema_id": "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+  "credential_proposal_dict": null,
+  "credential_offer_dict": null,
+  "credential_offer": null,
+  "credential_request": null,
+  "credential_request_metadata": null,
+  "credential_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "raw_credential": null,
+  "credential": null,
+  "auto_offer": false,
+  "auto_issue": false,
+  "auto_remove": false,
+  "error_msg": "credential definition identifier is not set in proposal",
+  "revoc_reg_id": null,
+  "revocation_id": null
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`state` (String; Optional): Issue-credential exchange state
+
+`created_at` (String; Optional): Time of record creation
+
+`updated_at` (String; Optional): Time of last record update
+
+`trace` (Boolean; Optional): Record trace information, based on agent configuration
+
+`credential_exchange_id` (String; Optional): Credential exchange identifier
+
+`connection_id` (String; Optional): Connection identifier
+
+`thread_id` (String; Optional): Thread identifier
+
+`parent_thread_id` (String; Optional): Parent thread identifier
+
+`initiator` (String; Optional): Issue-credential exchange initiator: self or external
+
+`role` (String; Optional): Issue-credential exchange role: holder or issuer
+
+`credential_definition_id` (String; Optional): Credential definition identifier
+
+`schema_id` (String; Optional): Schema identifier
+
+`credential_proposal_dict` (Dict; Optional): Serialized credential proposal message
+
+`credential_offer_dict` (Dict; Optional): Serialized credential offer message
+
+`credential_offer` (Dict; Optional): (Indy) credential offer
+
+`credential_request` (Dict; Optional): (Indy) credential request
+
+`credential_request_metadata` (Dict; Optional): (Indy) credential request metadata
+
+`credential_id` (String; Optional): Credential identifier
+
+`raw_credential` (Dict; Optional): Credential as received, prior to storage in holder wallet
+
+`credential` (Dict; Optional): Credential as stored
+
+`auto_offer` (Boolean; Optional): Holder choice to accept offer in this credential exchange
+
+`auto_issue` (Boolean; Optional): Issuer choice to issue to request in this credential exchange
+
+`auto_remove` (Boolean; Optional): Issuer choice to remove this credential exchange record when complete
+
+`error_msg` (String; Optional): Error message
+
+`revoc_reg_id` (String; Optional): Revocation registry identifier
+
+`revocation_id` (String; Optional): Credential identifier within revocation registry### presentation-exchange
+
+Presentation Exchange message.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/presentation-exchange",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "state": "verified",
+  "created_at": "2021-03-04 22:36:28Z",
+  "updated_at": "2021-03-04 22:36:28Z",
+  "trace": null,
+  "presentation_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "initiator": "self",
+  "role": "prover",
+  "presentation_proposal_dict": null,
+  "presentation_request": null,
+  "presentation_request_dict": null,
+  "presentation": null,
+  "verified": "true",
+  "auto_present": false,
+  "error_msg": "Invalid structure"
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`state` (String; Optional): Present-proof exchange state
+
+`created_at` (String; Optional): Time of record creation
+
+`updated_at` (String; Optional): Time of last record update
+
+`trace` (Boolean; Optional): Record trace information, based on agent configuration
+
+`presentation_exchange_id` (String; Optional): Presentation exchange identifier
+
+`connection_id` (String; Optional): Connection identifier
+
+`thread_id` (String; Optional): Thread identifier
+
+`initiator` (String; Optional): Present-proof exchange initiator: self or external
+
+`role` (String; Optional): Present-proof exchange role: prover or verifier
+
+`presentation_proposal_dict` (Dict; Optional): Serialized presentation proposal message
+
+`presentation_request` (Dict; Optional): (Indy) presentation request (also known as proof request)
+
+`presentation_request_dict` (Dict; Optional): Serialized presentation request message
+
+`presentation` (Dict; Optional): (Indy) presentation (also known as proof)
+
+`verified` (String; Optional): Whether presentation is verified: true or false
+
+`auto_present` (Boolean; Optional): Prover choice to auto-present proof as verifier requests
+
+`error_msg` (String; Optional): Error message### presentations-get-list
+
+Presentation get list message.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/presentations-get-list",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "connection_id": null,
+  "verified": null,
+  "~paginate": {
+    "limit": null,
+    "offset": null
+  }
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`connection_id` (String; Optional): 
+
+`verified` (String; Optional): 
+
+`~paginate` (Nested; Optional): Fields of paginate decorator.### presentations-list
+
+Presentation get list response message.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/presentations-list",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "results": null,
+  "~page": {
+    "count": null,
+    "offset": null,
+    "remaining": null
+  }
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`results` (List; Optional): 
+
+`~page` (Nested; Optional): Fields of page decorator.### presentation-request-approve
+
+Approve presentation request.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/presentation-request-approve",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "presentation_exchange_id": null
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`presentation_exchange_id` (String): ### send-credential-proposal
+
+Send Credential Proposal Message.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/send-credential-proposal",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "trace": false,
+  "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+  "schema_id": "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+  "schema_issuer_did": "WgWxqztrNooG92RXvxSTWv",
+  "schema_name": "preferences",
+  "schema_version": "1.0",
+  "issuer_did": "WgWxqztrNooG92RXvxSTWv",
+  "auto_remove": null,
+  "comment": null,
+  "credential_proposal": {
+    "@type": "issue-credential/1.0/credential-preview",
+    "attributes": {
+      "name": "favourite_drink",
+      "mime-type": "image/jpeg",
+      "value": "martini"
+    }
+  }
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`trace` (Boolean; Optional): Whether to trace event (default false)
+
+`connection_id` (UUID): Connection identifier
+
+`cred_def_id` (String; Optional): Credential definition identifier
+
+`schema_id` (String; Optional): Schema identifier
+
+`schema_issuer_did` (String; Optional): Schema issuer DID
+
+`schema_name` (String; Optional): Schema name
+
+`schema_version` (String; Optional): Schema version
+
+`issuer_did` (String; Optional): Credential issuer DID
+
+`auto_remove` (Boolean; Optional): Whether to remove the credential exchange record on completion (overrides --preserve-exchange-records configuration setting)
+
+`comment` (String; Optional): Human-readable comment
+
+`credential_proposal` (Nested): Credential preview schema.### send-presentation-proposal
+
+Presentation proposal message.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/send-presentation-proposal",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "trace": false,
+  "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "comment": null,
+  "presentation_proposal": {
+    "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/presentation-preview",
+    "attributes": {
+      "name": "favourite_drink",
+      "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+      "mime-type": "image/jpeg",
+      "value": "martini",
+      "referent": "0"
+    },
+    "predicates": {
+      "name": "high_score",
+      "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+      "predicate": ">=",
+      "threshold": null
+    }
+  },
+  "auto_present": null
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`trace` (Boolean; Optional): Whether to trace event (default false)
+
+`connection_id` (UUID): Connection identifier
+
+`comment` (String; Optional): Human-readable comment
+
+`presentation_proposal` (Nested): Presentation preview schema.
+
+`auto_present` (Boolean; Optional): Whether to respond automatically to presentation requests, building and presenting requested proof

--- a/docs/admin-holder/0.1/README.md
+++ b/docs/admin-holder/0.1/README.md
@@ -1,0 +1,67 @@
+Holder Admin Protocol
+=====================
+
+## Overview
+
+**Protocol URI:** `https://github.com/hyperledger/aries-toolbox/tree/master/docs/admin-holder/0.1`
+
+The holder admin protocol is used to manage credentials received by the
+connected agent.
+
+### Protocol Messages
+- [credentials-get-list](#credentials-get-list)
+- [credentials-list](#credentials-list)
+- [credentials-send-proposal](#credentials-send-proposal)
+- [credentials-proposal-sent](#credentials-proposal-sent)
+- [credentials-offer-received](#credentials-offer-received)
+- [credentials-accept-offer](#credentials-accept)
+- [presentations-get-list](#presentations-get-list)
+- [presentations-list](#presentations-list)
+- [presentations-send-proposal](#presentations-send-proposal)
+- [presentations-proposal-sent](#presentations-proposal-sent)
+- [presentations-request-received](#presentations-request-received)
+- [presentations-accept-request](#presentations-accept-request)
+
+
+## Common Elements
+
+### Credential Representation
+
+Example:
+
+```jsonc
+{
+	"issuer_did": "<issuer did>",
+	"issuer_connection_id": "<connection id>",
+	"name": "<credential name>",
+	"comment": "comment about the credential"
+	"received_at": "<datetime>",
+	"attributes": [
+		{
+			"name": "attribute_name",
+			"value": "value"
+		},
+		...
+	],
+	"metadata": {
+		"schema_id": "<schema id>",
+		"cred_def_id": "<cred def id>"
+	},
+	"raw_repr": { ... }
+}
+```
+
+
+## Message Definitions
+
+> _**Note:**_ Some attributes are shortened or omitted from the examples in this
+> section, such as the `@id` and `@type` attributes. The omission is for brevity
+> and clarity of the example and it should be assumed that each example message
+> contains all attributes required to be processed by the receiving agent.
+
+### credentials-get-list
+Retrieve a list of credentials held by the connected agent.
+
+### credentials-list
+Response to `credentials-get-list` containing list of credentials held by the
+connected agent.

--- a/docs/admin-holder/0.1/README.md
+++ b/docs/admin-holder/0.1/README.md
@@ -6,102 +6,25 @@
 
 Define messages for credential holder admin protocols.
 
-### Protocol Messages- [credential-exchange](#credential-exchange)- [credentials-get-list](#credentials-get-list)- [credentials-list](#credentials-list)- [credential-offer-accept](#credential-offer-accept)- [credential-offer-received](#credential-offer-received)- [credential-request-sent](#credential-request-sent)- [presentation-exchange](#presentation-exchange)- [presentations-get-list](#presentations-get-list)- [presentations-list](#presentations-list)- [presentation-request-approve](#presentation-request-approve)- [send-credential-proposal](#send-credential-proposal)- [send-presentation-proposal](#send-presentation-proposal)## Message Definitions### credential-exchange
+### Protocol Messages
+- [credentials-get-list](#credentials-get-list)
+- [credentials-list](#credentials-list)
+- [credential-offer-accept](#credential-offer-accept)
+- [credential-offer-received](#credential-offer-received)
+- [credential-request-sent](#credential-request-sent)
+- [credential-received](#credential-received)
+- [send-credential-proposal](#send-credential-proposal)
+- [credential-exchange](#credential-exchange)
+- [presentations-get-list](#presentations-get-list)
+- [presentations-list](#presentations-list)
+- [presentation-request-approve](#presentation-request-approve)
+- [send-presentation-proposal](#send-presentation-proposal)
+- [presentation-exchange](#presentation-exchange)
 
-Credential exchange message.
 
-Example:
+## Message Definitions
 
-```json
-{
-  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-exchange",
-  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "state": "credential_acked",
-  "created_at": "2021-03-04 22:36:28Z",
-  "updated_at": "2021-03-04 22:36:28Z",
-  "trace": null,
-  "credential_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "parent_thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "initiator": "self",
-  "role": "issuer",
-  "credential_definition_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
-  "schema_id": "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
-  "credential_proposal_dict": null,
-  "credential_offer_dict": null,
-  "credential_offer": null,
-  "credential_request": null,
-  "credential_request_metadata": null,
-  "credential_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "raw_credential": null,
-  "credential": null,
-  "auto_offer": false,
-  "auto_issue": false,
-  "auto_remove": false,
-  "error_msg": "credential definition identifier is not set in proposal",
-  "revoc_reg_id": null,
-  "revocation_id": null
-}
-```
-
-#### Fields
-
-`@type` (String): Message type
-
-`@id` (String; Optional): Message identifier
-
-`state` (String; Optional): Issue-credential exchange state
-
-`created_at` (String; Optional): Time of record creation
-
-`updated_at` (String; Optional): Time of last record update
-
-`trace` (Boolean; Optional): Record trace information, based on agent configuration
-
-`credential_exchange_id` (String; Optional): Credential exchange identifier
-
-`connection_id` (String; Optional): Connection identifier
-
-`thread_id` (String; Optional): Thread identifier
-
-`parent_thread_id` (String; Optional): Parent thread identifier
-
-`initiator` (String; Optional): Issue-credential exchange initiator: self or external
-
-`role` (String; Optional): Issue-credential exchange role: holder or issuer
-
-`credential_definition_id` (String; Optional): Credential definition identifier
-
-`schema_id` (String; Optional): Schema identifier
-
-`credential_proposal_dict` (Dict; Optional): Serialized credential proposal message
-
-`credential_offer_dict` (Dict; Optional): Serialized credential offer message
-
-`credential_offer` (Dict; Optional): (Indy) credential offer
-
-`credential_request` (Dict; Optional): (Indy) credential request
-
-`credential_request_metadata` (Dict; Optional): (Indy) credential request metadata
-
-`credential_id` (String; Optional): Credential identifier
-
-`raw_credential` (Dict; Optional): Credential as received, prior to storage in holder wallet
-
-`credential` (Dict; Optional): Credential as stored
-
-`auto_offer` (Boolean; Optional): Holder choice to accept offer in this credential exchange
-
-`auto_issue` (Boolean; Optional): Issuer choice to issue to request in this credential exchange
-
-`auto_remove` (Boolean; Optional): Issuer choice to remove this credential exchange record when complete
-
-`error_msg` (String; Optional): Error message
-
-`revoc_reg_id` (String; Optional): Revocation registry identifier
-
-`revocation_id` (String; Optional): Credential identifier within revocation registry### credentials-get-list
+### credentials-get-list
 
 Credential list retrieval message.
 
@@ -182,8 +105,8 @@ Example:
   "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-offer-received",
   "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "state": "credential_acked",
-  "created_at": "2021-03-04 22:36:28Z",
-  "updated_at": "2021-03-04 22:36:28Z",
+  "created_at": "2021-03-04 22:59:34Z",
+  "updated_at": "2021-03-04 22:59:34Z",
   "trace": null,
   "credential_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
@@ -277,8 +200,8 @@ Example:
   "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-request-sent",
   "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "state": "credential_acked",
-  "created_at": "2021-03-04 22:36:28Z",
-  "updated_at": "2021-03-04 22:36:28Z",
+  "created_at": "2021-03-04 22:59:34Z",
+  "updated_at": "2021-03-04 22:59:34Z",
   "trace": null,
   "credential_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
@@ -361,32 +284,42 @@ Example:
 
 `revoc_reg_id` (String; Optional): Revocation registry identifier
 
-`revocation_id` (String; Optional): Credential identifier within revocation registry### presentation-exchange
+`revocation_id` (String; Optional): Credential identifier within revocation registry### credential-received
 
-Presentation Exchange message.
+Credential received notification message.
 
 Example:
 
 ```json
 {
-  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/presentation-exchange",
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-received",
   "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "state": "verified",
-  "created_at": "2021-03-04 22:36:28Z",
-  "updated_at": "2021-03-04 22:36:28Z",
+  "state": "credential_acked",
+  "created_at": "2021-03-04 22:59:34Z",
+  "updated_at": "2021-03-04 22:59:34Z",
   "trace": null,
-  "presentation_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "credential_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "parent_thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "initiator": "self",
-  "role": "prover",
-  "presentation_proposal_dict": null,
-  "presentation_request": null,
-  "presentation_request_dict": null,
-  "presentation": null,
-  "verified": "true",
-  "auto_present": false,
-  "error_msg": "Invalid structure"
+  "role": "issuer",
+  "credential_definition_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+  "schema_id": "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+  "credential_proposal_dict": null,
+  "credential_offer_dict": null,
+  "credential_offer": null,
+  "credential_request": null,
+  "credential_request_metadata": null,
+  "credential_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "raw_credential": null,
+  "credential": null,
+  "auto_offer": false,
+  "auto_issue": false,
+  "auto_remove": false,
+  "error_msg": "credential definition identifier is not set in proposal",
+  "revoc_reg_id": null,
+  "revocation_id": null
 }
 ```
 
@@ -396,7 +329,7 @@ Example:
 
 `@id` (String; Optional): Message identifier
 
-`state` (String; Optional): Present-proof exchange state
+`state` (String; Optional): Issue-credential exchange state
 
 `created_at` (String; Optional): Time of record creation
 
@@ -404,29 +337,201 @@ Example:
 
 `trace` (Boolean; Optional): Record trace information, based on agent configuration
 
-`presentation_exchange_id` (String; Optional): Presentation exchange identifier
+`credential_exchange_id` (String; Optional): Credential exchange identifier
 
 `connection_id` (String; Optional): Connection identifier
 
 `thread_id` (String; Optional): Thread identifier
 
-`initiator` (String; Optional): Present-proof exchange initiator: self or external
+`parent_thread_id` (String; Optional): Parent thread identifier
 
-`role` (String; Optional): Present-proof exchange role: prover or verifier
+`initiator` (String; Optional): Issue-credential exchange initiator: self or external
 
-`presentation_proposal_dict` (Dict; Optional): Serialized presentation proposal message
+`role` (String; Optional): Issue-credential exchange role: holder or issuer
 
-`presentation_request` (Dict; Optional): (Indy) presentation request (also known as proof request)
+`credential_definition_id` (String; Optional): Credential definition identifier
 
-`presentation_request_dict` (Dict; Optional): Serialized presentation request message
+`schema_id` (String; Optional): Schema identifier
 
-`presentation` (Dict; Optional): (Indy) presentation (also known as proof)
+`credential_proposal_dict` (Dict; Optional): Serialized credential proposal message
 
-`verified` (String; Optional): Whether presentation is verified: true or false
+`credential_offer_dict` (Dict; Optional): Serialized credential offer message
 
-`auto_present` (Boolean; Optional): Prover choice to auto-present proof as verifier requests
+`credential_offer` (Dict; Optional): (Indy) credential offer
 
-`error_msg` (String; Optional): Error message### presentations-get-list
+`credential_request` (Dict; Optional): (Indy) credential request
+
+`credential_request_metadata` (Dict; Optional): (Indy) credential request metadata
+
+`credential_id` (String; Optional): Credential identifier
+
+`raw_credential` (Dict; Optional): Credential as received, prior to storage in holder wallet
+
+`credential` (Dict; Optional): Credential as stored
+
+`auto_offer` (Boolean; Optional): Holder choice to accept offer in this credential exchange
+
+`auto_issue` (Boolean; Optional): Issuer choice to issue to request in this credential exchange
+
+`auto_remove` (Boolean; Optional): Issuer choice to remove this credential exchange record when complete
+
+`error_msg` (String; Optional): Error message
+
+`revoc_reg_id` (String; Optional): Revocation registry identifier
+
+`revocation_id` (String; Optional): Credential identifier within revocation registry### send-credential-proposal
+
+Send Credential Proposal Message.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/send-credential-proposal",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "trace": false,
+  "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+  "schema_id": "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+  "schema_issuer_did": "WgWxqztrNooG92RXvxSTWv",
+  "schema_name": "preferences",
+  "schema_version": "1.0",
+  "issuer_did": "WgWxqztrNooG92RXvxSTWv",
+  "auto_remove": null,
+  "comment": null,
+  "credential_proposal": {
+    "@type": "issue-credential/1.0/credential-preview",
+    "attributes": {
+      "name": "favourite_drink",
+      "mime-type": "image/jpeg",
+      "value": "martini"
+    }
+  }
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`trace` (Boolean; Optional): Whether to trace event (default false)
+
+`connection_id` (UUID): Connection identifier
+
+`cred_def_id` (String; Optional): Credential definition identifier
+
+`schema_id` (String; Optional): Schema identifier
+
+`schema_issuer_did` (String; Optional): Schema issuer DID
+
+`schema_name` (String; Optional): Schema name
+
+`schema_version` (String; Optional): Schema version
+
+`issuer_did` (String; Optional): Credential issuer DID
+
+`auto_remove` (Boolean; Optional): Whether to remove the credential exchange record on completion (overrides --preserve-exchange-records configuration setting)
+
+`comment` (String; Optional): Human-readable comment
+
+`credential_proposal` (Nested): Credential preview schema.### credential-exchange
+
+Credential exchange message.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-exchange",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "state": "credential_acked",
+  "created_at": "2021-03-04 22:59:34Z",
+  "updated_at": "2021-03-04 22:59:34Z",
+  "trace": null,
+  "credential_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "parent_thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "initiator": "self",
+  "role": "issuer",
+  "credential_definition_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+  "schema_id": "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+  "credential_proposal_dict": null,
+  "credential_offer_dict": null,
+  "credential_offer": null,
+  "credential_request": null,
+  "credential_request_metadata": null,
+  "credential_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "raw_credential": null,
+  "credential": null,
+  "auto_offer": false,
+  "auto_issue": false,
+  "auto_remove": false,
+  "error_msg": "credential definition identifier is not set in proposal",
+  "revoc_reg_id": null,
+  "revocation_id": null
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`state` (String; Optional): Issue-credential exchange state
+
+`created_at` (String; Optional): Time of record creation
+
+`updated_at` (String; Optional): Time of last record update
+
+`trace` (Boolean; Optional): Record trace information, based on agent configuration
+
+`credential_exchange_id` (String; Optional): Credential exchange identifier
+
+`connection_id` (String; Optional): Connection identifier
+
+`thread_id` (String; Optional): Thread identifier
+
+`parent_thread_id` (String; Optional): Parent thread identifier
+
+`initiator` (String; Optional): Issue-credential exchange initiator: self or external
+
+`role` (String; Optional): Issue-credential exchange role: holder or issuer
+
+`credential_definition_id` (String; Optional): Credential definition identifier
+
+`schema_id` (String; Optional): Schema identifier
+
+`credential_proposal_dict` (Dict; Optional): Serialized credential proposal message
+
+`credential_offer_dict` (Dict; Optional): Serialized credential offer message
+
+`credential_offer` (Dict; Optional): (Indy) credential offer
+
+`credential_request` (Dict; Optional): (Indy) credential request
+
+`credential_request_metadata` (Dict; Optional): (Indy) credential request metadata
+
+`credential_id` (String; Optional): Credential identifier
+
+`raw_credential` (Dict; Optional): Credential as received, prior to storage in holder wallet
+
+`credential` (Dict; Optional): Credential as stored
+
+`auto_offer` (Boolean; Optional): Holder choice to accept offer in this credential exchange
+
+`auto_issue` (Boolean; Optional): Issuer choice to issue to request in this credential exchange
+
+`auto_remove` (Boolean; Optional): Issuer choice to remove this credential exchange record when complete
+
+`error_msg` (String; Optional): Error message
+
+`revoc_reg_id` (String; Optional): Revocation registry identifier
+
+`revocation_id` (String; Optional): Credential identifier within revocation registry### presentations-get-list
 
 Presentation get list message.
 
@@ -502,64 +607,7 @@ Example:
 
 `@id` (String; Optional): Message identifier
 
-`presentation_exchange_id` (String): ### send-credential-proposal
-
-Send Credential Proposal Message.
-
-Example:
-
-```json
-{
-  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/send-credential-proposal",
-  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "trace": false,
-  "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
-  "schema_id": "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
-  "schema_issuer_did": "WgWxqztrNooG92RXvxSTWv",
-  "schema_name": "preferences",
-  "schema_version": "1.0",
-  "issuer_did": "WgWxqztrNooG92RXvxSTWv",
-  "auto_remove": null,
-  "comment": null,
-  "credential_proposal": {
-    "@type": "issue-credential/1.0/credential-preview",
-    "attributes": {
-      "name": "favourite_drink",
-      "mime-type": "image/jpeg",
-      "value": "martini"
-    }
-  }
-}
-```
-
-#### Fields
-
-`@type` (String): Message type
-
-`@id` (String; Optional): Message identifier
-
-`trace` (Boolean; Optional): Whether to trace event (default false)
-
-`connection_id` (UUID): Connection identifier
-
-`cred_def_id` (String; Optional): Credential definition identifier
-
-`schema_id` (String; Optional): Schema identifier
-
-`schema_issuer_did` (String; Optional): Schema issuer DID
-
-`schema_name` (String; Optional): Schema name
-
-`schema_version` (String; Optional): Schema version
-
-`issuer_did` (String; Optional): Credential issuer DID
-
-`auto_remove` (Boolean; Optional): Whether to remove the credential exchange record on completion (overrides --preserve-exchange-records configuration setting)
-
-`comment` (String; Optional): Human-readable comment
-
-`credential_proposal` (Nested): Credential preview schema.### send-presentation-proposal
+`presentation_exchange_id` (String): ### send-presentation-proposal
 
 Presentation proposal message.
 
@@ -606,4 +654,69 @@ Example:
 
 `presentation_proposal` (Nested): Presentation preview schema.
 
-`auto_present` (Boolean; Optional): Whether to respond automatically to presentation requests, building and presenting requested proof
+`auto_present` (Boolean; Optional): Whether to respond automatically to presentation requests, building and presenting requested proof### presentation-exchange
+
+Presentation Exchange message.
+
+Example:
+
+```json
+{
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/presentation-exchange",
+  "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "state": "verified",
+  "created_at": "2021-03-04 22:59:34Z",
+  "updated_at": "2021-03-04 22:59:34Z",
+  "trace": null,
+  "presentation_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "thread_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "initiator": "self",
+  "role": "prover",
+  "presentation_proposal_dict": null,
+  "presentation_request": null,
+  "presentation_request_dict": null,
+  "presentation": null,
+  "verified": "true",
+  "auto_present": false,
+  "error_msg": "Invalid structure"
+}
+```
+
+#### Fields
+
+`@type` (String): Message type
+
+`@id` (String; Optional): Message identifier
+
+`state` (String; Optional): Present-proof exchange state
+
+`created_at` (String; Optional): Time of record creation
+
+`updated_at` (String; Optional): Time of last record update
+
+`trace` (Boolean; Optional): Record trace information, based on agent configuration
+
+`presentation_exchange_id` (String; Optional): Presentation exchange identifier
+
+`connection_id` (String; Optional): Connection identifier
+
+`thread_id` (String; Optional): Thread identifier
+
+`initiator` (String; Optional): Present-proof exchange initiator: self or external
+
+`role` (String; Optional): Present-proof exchange role: prover or verifier
+
+`presentation_proposal_dict` (Dict; Optional): Serialized presentation proposal message
+
+`presentation_request` (Dict; Optional): (Indy) presentation request (also known as proof request)
+
+`presentation_request_dict` (Dict; Optional): Serialized presentation request message
+
+`presentation` (Dict; Optional): (Indy) presentation (also known as proof)
+
+`verified` (String; Optional): Whether presentation is verified: true or false
+
+`auto_present` (Boolean; Optional): Prover choice to auto-present proof as verifier requests
+
+`error_msg` (String; Optional): Error message

--- a/docs/admin-holder/0.1/README.md
+++ b/docs/admin-holder/0.1/README.md
@@ -35,8 +35,8 @@ Example:
   "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credentials-get-list",
   "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "~paginate": {
-    "limit": null,
-    "offset": null
+    "limit": 10,
+    "offset": 20
   }
 }
 ```
@@ -47,7 +47,7 @@ Example:
 
 `@id` (String; Optional): Message identifier
 
-`~paginate` (Nested; Optional): Fields of paginate decorator.
+`~paginate` (Nested; Optional): Paginate decorator for messages querying for a paginated object.
 
 ### credentials-list
 
@@ -76,7 +76,7 @@ Example:
 
 `results` (List; Optional): 
 
-`~page` (Nested; Optional): Fields of page decorator.
+`~page` (Nested; Optional): Page decorator for messages containing a paginated object.
 
 ### credential-offer-accept
 
@@ -111,8 +111,8 @@ Example:
   "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-offer-received",
   "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "state": "credential_acked",
-  "created_at": "2021-03-04 22:59:34Z",
-  "updated_at": "2021-03-04 22:59:34Z",
+  "created_at": "2021-03-05 02:02:17Z",
+  "updated_at": "2021-03-05 02:02:17Z",
   "trace": null,
   "credential_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
@@ -208,8 +208,8 @@ Example:
   "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-request-sent",
   "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "state": "credential_acked",
-  "created_at": "2021-03-04 22:59:34Z",
-  "updated_at": "2021-03-04 22:59:34Z",
+  "created_at": "2021-03-05 02:02:17Z",
+  "updated_at": "2021-03-05 02:02:17Z",
   "trace": null,
   "credential_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
@@ -305,8 +305,8 @@ Example:
   "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-received",
   "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "state": "credential_acked",
-  "created_at": "2021-03-04 22:59:34Z",
-  "updated_at": "2021-03-04 22:59:34Z",
+  "created_at": "2021-03-05 02:02:17Z",
+  "updated_at": "2021-03-05 02:02:17Z",
   "trace": null,
   "credential_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
@@ -448,7 +448,7 @@ Example:
 
 `comment` (String; Optional): Human-readable comment
 
-`credential_proposal` (Nested): Credential preview schema.
+`credential_proposal` (Nested): Class representing a credential preview inner object.
 
 ### credential-exchange
 
@@ -461,8 +461,8 @@ Example:
   "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-exchange",
   "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "state": "credential_acked",
-  "created_at": "2021-03-04 22:59:34Z",
-  "updated_at": "2021-03-04 22:59:34Z",
+  "created_at": "2021-03-05 02:02:17Z",
+  "updated_at": "2021-03-05 02:02:17Z",
   "trace": null,
   "credential_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
@@ -560,8 +560,8 @@ Example:
   "connection_id": null,
   "verified": null,
   "~paginate": {
-    "limit": null,
-    "offset": null
+    "limit": 10,
+    "offset": 20
   }
 }
 ```
@@ -576,7 +576,7 @@ Example:
 
 `verified` (String; Optional): 
 
-`~paginate` (Nested; Optional): Fields of paginate decorator.
+`~paginate` (Nested; Optional): Paginate decorator for messages querying for a paginated object.
 
 ### presentations-list
 
@@ -605,7 +605,7 @@ Example:
 
 `results` (List; Optional): 
 
-`~page` (Nested; Optional): Fields of page decorator.
+`~page` (Nested; Optional): Page decorator for messages containing a paginated object.
 
 ### presentation-request-approve
 
@@ -674,7 +674,7 @@ Example:
 
 `comment` (String; Optional): Human-readable comment
 
-`presentation_proposal` (Nested): Presentation preview schema.
+`presentation_proposal` (Nested): Class representing presentation preview.
 
 `auto_present` (Boolean; Optional): Whether to respond automatically to presentation requests, building and presenting requested proof
 
@@ -689,8 +689,8 @@ Example:
   "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/presentation-exchange",
   "@id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "state": "verified",
-  "created_at": "2021-03-04 22:59:34Z",
-  "updated_at": "2021-03-04 22:59:34Z",
+  "created_at": "2021-03-05 02:02:17Z",
+  "updated_at": "2021-03-05 02:02:17Z",
   "trace": null,
   "presentation_exchange_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",

--- a/docs/admin-holder/0.1/README.md
+++ b/docs/admin-holder/0.1/README.md
@@ -47,7 +47,9 @@ Example:
 
 `@id` (String; Optional): Message identifier
 
-`~paginate` (Nested; Optional): Fields of paginate decorator.### credentials-list
+`~paginate` (Nested; Optional): Fields of paginate decorator.
+
+### credentials-list
 
 Credential list message.
 
@@ -74,7 +76,9 @@ Example:
 
 `results` (List; Optional): 
 
-`~page` (Nested; Optional): Fields of page decorator.### credential-offer-accept
+`~page` (Nested; Optional): Fields of page decorator.
+
+### credential-offer-accept
 
 Credential offer accept message.
 
@@ -94,7 +98,9 @@ Example:
 
 `@id` (String; Optional): Message identifier
 
-`credential_exchange_id` (String): ### credential-offer-received
+`credential_exchange_id` (String): 
+
+### credential-offer-received
 
 Credential offer received message.
 
@@ -189,7 +195,9 @@ Example:
 
 `revoc_reg_id` (String; Optional): Revocation registry identifier
 
-`revocation_id` (String; Optional): Credential identifier within revocation registry### credential-request-sent
+`revocation_id` (String; Optional): Credential identifier within revocation registry
+
+### credential-request-sent
 
 Credential offer acceptance received and credential request sent.
 
@@ -284,7 +292,9 @@ Example:
 
 `revoc_reg_id` (String; Optional): Revocation registry identifier
 
-`revocation_id` (String; Optional): Credential identifier within revocation registry### credential-received
+`revocation_id` (String; Optional): Credential identifier within revocation registry
+
+### credential-received
 
 Credential received notification message.
 
@@ -379,7 +389,9 @@ Example:
 
 `revoc_reg_id` (String; Optional): Revocation registry identifier
 
-`revocation_id` (String; Optional): Credential identifier within revocation registry### send-credential-proposal
+`revocation_id` (String; Optional): Credential identifier within revocation registry
+
+### send-credential-proposal
 
 Send Credential Proposal Message.
 
@@ -436,7 +448,9 @@ Example:
 
 `comment` (String; Optional): Human-readable comment
 
-`credential_proposal` (Nested): Credential preview schema.### credential-exchange
+`credential_proposal` (Nested): Credential preview schema.
+
+### credential-exchange
 
 Credential exchange message.
 
@@ -531,7 +545,9 @@ Example:
 
 `revoc_reg_id` (String; Optional): Revocation registry identifier
 
-`revocation_id` (String; Optional): Credential identifier within revocation registry### presentations-get-list
+`revocation_id` (String; Optional): Credential identifier within revocation registry
+
+### presentations-get-list
 
 Presentation get list message.
 
@@ -560,7 +576,9 @@ Example:
 
 `verified` (String; Optional): 
 
-`~paginate` (Nested; Optional): Fields of paginate decorator.### presentations-list
+`~paginate` (Nested; Optional): Fields of paginate decorator.
+
+### presentations-list
 
 Presentation get list response message.
 
@@ -587,7 +605,9 @@ Example:
 
 `results` (List; Optional): 
 
-`~page` (Nested; Optional): Fields of page decorator.### presentation-request-approve
+`~page` (Nested; Optional): Fields of page decorator.
+
+### presentation-request-approve
 
 Approve presentation request.
 
@@ -607,7 +627,9 @@ Example:
 
 `@id` (String; Optional): Message identifier
 
-`presentation_exchange_id` (String): ### send-presentation-proposal
+`presentation_exchange_id` (String): 
+
+### send-presentation-proposal
 
 Presentation proposal message.
 
@@ -654,7 +676,9 @@ Example:
 
 `presentation_proposal` (Nested): Presentation preview schema.
 
-`auto_present` (Boolean; Optional): Whether to respond automatically to presentation requests, building and presenting requested proof### presentation-exchange
+`auto_present` (Boolean; Optional): Whether to respond automatically to presentation requests, building and presenting requested proof
+
+### presentation-exchange
 
 Presentation Exchange message.
 

--- a/docs/admin-holder/0.1/credential-exchange/README.md
+++ b/docs/admin-holder/0.1/credential-exchange/README.md
@@ -1,0 +1,1 @@
+See [credential-exchange](/docs/admin-holder/0.1/README.md#credential-exchange).

--- a/docs/admin-holder/0.1/credential-offer-accept/README.md
+++ b/docs/admin-holder/0.1/credential-offer-accept/README.md
@@ -1,0 +1,1 @@
+See [credential-offer-accept](/docs/admin-holder/0.1/README.md#credential-offer-accept).

--- a/docs/admin-holder/0.1/credential-offer-received/README.md
+++ b/docs/admin-holder/0.1/credential-offer-received/README.md
@@ -1,0 +1,1 @@
+See [credential-offer-received](/docs/admin-holder/0.1/README.md#credential-offer-received).

--- a/docs/admin-holder/0.1/credential-received/README.md
+++ b/docs/admin-holder/0.1/credential-received/README.md
@@ -1,0 +1,1 @@
+See [credential-received](/docs/admin-holder/0.1/README.md#credential-received).

--- a/docs/admin-holder/0.1/credential-request-sent/README.md
+++ b/docs/admin-holder/0.1/credential-request-sent/README.md
@@ -1,0 +1,1 @@
+See [credential-request-sent](/docs/admin-holder/0.1/README.md#credential-request-sent).

--- a/docs/admin-holder/0.1/credentials-get-list/README.md
+++ b/docs/admin-holder/0.1/credentials-get-list/README.md
@@ -1,0 +1,1 @@
+See [credentials-get-list](/docs/admin-holder/0.1/README.md#credentials-get-list).

--- a/docs/admin-holder/0.1/credentials-list/README.md
+++ b/docs/admin-holder/0.1/credentials-list/README.md
@@ -1,0 +1,1 @@
+See [credentials-list](/docs/admin-holder/0.1/README.md#credentials-list).

--- a/docs/admin-holder/0.1/presentation-exchange/README.md
+++ b/docs/admin-holder/0.1/presentation-exchange/README.md
@@ -1,0 +1,1 @@
+See [presentation-exchange](/docs/admin-holder/0.1/README.md#presentation-exchange).

--- a/docs/admin-holder/0.1/presentation-request-approve/README.md
+++ b/docs/admin-holder/0.1/presentation-request-approve/README.md
@@ -1,0 +1,1 @@
+See [presentation-request-approve](/docs/admin-holder/0.1/README.md#presentation-request-approve).

--- a/docs/admin-holder/0.1/presentations-get-list/README.md
+++ b/docs/admin-holder/0.1/presentations-get-list/README.md
@@ -1,0 +1,1 @@
+See [presentations-get-list](/docs/admin-holder/0.1/README.md#presentations-get-list).

--- a/docs/admin-holder/0.1/presentations-list/README.md
+++ b/docs/admin-holder/0.1/presentations-list/README.md
@@ -1,0 +1,1 @@
+See [presentations-list](/docs/admin-holder/0.1/README.md#presentations-list).

--- a/docs/admin-holder/0.1/send-credential-proposal/README.md
+++ b/docs/admin-holder/0.1/send-credential-proposal/README.md
@@ -1,0 +1,1 @@
+See [send-credential-proposal](/docs/admin-holder/0.1/README.md#send-credential-proposal).

--- a/docs/admin-holder/0.1/send-presentation-proposal/README.md
+++ b/docs/admin-holder/0.1/send-presentation-proposal/README.md
@@ -1,0 +1,1 @@
+See [send-presentation-proposal](/docs/admin-holder/0.1/README.md#send-presentation-proposal).


### PR DESCRIPTION
This PR adds documentation for the Admin Holder protocol. The added documentation represents the protocol as currently implemented; as a result, these docs are accurate but do not reflect where we want this protocol to be in the long run. A future revision will be made to bring the protocol more in line with the other admin protocols and to make the protocol less ACA-Py specific.