### PR TITLE
docs: add docs for admin-schemas

### DIFF
--- a/docs/admin-holder/0.1/presentation-get-matching-credentials/README.md
+++ b/docs/admin-holder/0.1/presentation-get-matching-credentials/README.md
@@ -1,0 +1,1 @@
+See [presentation-get-matching-credentials](/docs/admin-holder/0.1/README.md#presentation-get-matching-credentials).

--- a/docs/admin-holder/0.1/presentation-matching-credentials/README.md
+++ b/docs/admin-holder/0.1/presentation-matching-credentials/README.md
@@ -1,0 +1,1 @@
+See [presentation-matching-credentials](/docs/admin-holder/0.1/README.md#presentation-matching-credentials).

--- a/docs/admin-invitations/0.1/create-invitation/README.md
+++ b/docs/admin-invitations/0.1/create-invitation/README.md
@@ -1,1 +1,0 @@
-See [create-invitation](/docs/admin-invitations/0.1/README.md#create-invitation).

--- a/docs/admin-invitations/0.1/create/README.md
+++ b/docs/admin-invitations/0.1/create/README.md
@@ -1,0 +1,1 @@
+See [create](/docs/admin-invitations/0.1/README.md#create).

--- a/docs/admin-schemas/0.1/README.md
+++ b/docs/admin-schemas/0.1/README.md
@@ -1,0 +1,128 @@
+# Schemas Admin Protocol
+
+## Overview
+**Protocol URI:** `did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-schemas/0.1`
+
+
+#### Protocol Messages
+* [send-schema](#send-schema)
+* [schema-id](#schema-id)
+* [schema-get](#schema-id)
+* [schema](#schema)
+* [schema-get-list](#schema-get-list)
+* [schema-list](#schema-list)
+
+## Message Definitions
+
+### Send schema
+Create a schema by inputting a name, version number, and attributes.
+
+```
+{
+    "@type":"did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-schemas/0.1/send-schema",
+    "schema_name": "Alice's Test Schema",
+    "schema_version": "1.0",
+    "attributes": [
+        "test_attr_0",
+        "test_attr_1",
+        "test_attr_2"
+    ],
+    "@id": "ad285eef-a5e4-4cea-9a40-12f3294d1826",
+    "~transport": {
+    "return_route": "all"
+    }
+}
+```
+
+### Schema ID
+Response to a `send-schema` message.
+```
+{
+    "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-schemas/0.1/schema-id",
+    "@id": "c3091caa-ebcd-4d2c-a2fc-636893ee6f43",
+    "~thread": {
+        "thid": "ad285eef-a5e4-4cea-9a40-12f3294d1826"
+    },
+    "schema_id": "UjF64u8jDEEuRve7PKQGUo:2:Alice's Test Schema:1.0"
+}
+```
+
+
+### Schema get
+Retrieve a pre-existing schema using the schema ID.
+```
+{
+    "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-schemas/0.1/schema-get",
+    "schema_id": "UjF64u8jDEEuRve7PKQGUo:2:Alice's Test Schema:1.0",
+    "@id": "32a22f71-eed6-4113-8732-c791302da893",
+    "~transport": {
+        "return_route": "all"
+    }
+}
+```
+
+### Schema
+Response to a `schema-get` message.
+```
+{
+    "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-schemas/0.1/schema",
+    "@id": "7bc2adbc-e1f2-43be-9d8c-0890fb4e7180",
+    "~thread": {
+        "thid": "32a22f71-eed6-4113-8732-c791302da893"
+    },
+    "schema_version": "1.0",
+    "updated_at": "2021-07-12 20:55:44.464312Z",
+    "state": "written",
+    "attributes": [
+        "test_attr_0",
+        "test_attr_2",
+        "test_attr_1"
+    ],
+    "schema_id": "UjF64u8jDEEuRve7PKQGUo:2:Alice's Test Schema:1.0",
+    "created_at": "2021-07-12 20:55:44.464312Z",
+    "author": "other",
+    "schema_name": "Alice's Test Schema"
+}
+```
+
+
+
+### Schema get list
+Retrieve the list of schemas.
+```
+{
+    "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-schemas/0.1/schema-get-list",
+    "@id": "f8639a9c-b1aa-4df5-ad93-bb91d94ebb1c",
+    "~transport": {
+        "return_route": "all"
+    }
+}
+```
+
+### Schema list
+Response message to `schema-get-list`.
+```
+{
+    "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-schemas/0.1/schema-list",
+    "@id": "a94ef367-1892-435b-8522-dc38889dfccb",
+    "~thread": {
+        "thid": "f8639a9c-b1aa-4df5-ad93-bb91d94ebb1c"
+    },
+    "results": [
+        {
+            "schema_name": "Alice's Test Schema",
+            "state": "written",
+            "schema_id": "UjF64u8jDEEuRve7PKQGUo:2:Alice's Test Schema:1.0",
+            "schema_version": "1.0",
+            "attributes": [
+                "test_attr_0",
+                "test_attr_1",
+                "test_attr_2"
+            ],
+            "updated_at": "2021-07-12 20:45:43.493398Z",
+            "author": "self",
+            "created_at": "2021-07-12 20:45:43.493398Z"
+        }
+    ]
+}
+```

--- a/docs/admin-schemas/0.1/schema-get-list/README.md
+++ b/docs/admin-schemas/0.1/schema-get-list/README.md
@@ -1,0 +1,1 @@
+See [schema-get-list](/docs/admin-schemas/0.1/README.md#schema-get-list).

--- a/docs/admin-schemas/0.1/schema-get/README.md
+++ b/docs/admin-schemas/0.1/schema-get/README.md
@@ -1,0 +1,1 @@
+See [schema-get](/docs/admin-schemas/0.1/README.md#schema-id).

--- a/docs/admin-schemas/0.1/schema-id/README.md
+++ b/docs/admin-schemas/0.1/schema-id/README.md
@@ -1,0 +1,1 @@
+See [schema-id](/docs/admin-schemas/0.1/README.md#schema-id).

--- a/docs/admin-schemas/0.1/schema-list/README.md
+++ b/docs/admin-schemas/0.1/schema-list/README.md
@@ -1,0 +1,1 @@
+See [schema-list](/docs/admin-schemas/0.1/README.md#schema-list).

--- a/docs/admin-schemas/0.1/schema/README.md
+++ b/docs/admin-schemas/0.1/schema/README.md
@@ -1,0 +1,1 @@
+See [schema](/docs/admin-schemas/0.1/README.md#schema).

--- a/docs/admin-schemas/0.1/send-schema/README.md
+++ b/docs/admin-schemas/0.1/send-schema/README.md
@@ -1,0 +1,1 @@
+See [send-schema](/docs/admin-schemas/0.1/README.md#send-schema).


### PR DESCRIPTION
Credit to @cjhowland for her work on this (originally written in a hackmd doc).

To generate new docs for protocols, first create a directory structure matching the following template: `admin-PROTOCOLHERE/VERSIONHERE`.

For example, for the schema admin protocol: `admin-schemas/0.1`.

Then, create a new `README.md` file in that directory. Populate this file with protocol documentation. The folder generator looks for specific lines in the file to generate folders from. There must be a line matching:

```
## Protocol Messages
```

(This line can have one or more `#` at the front)

This line is to be followed by lines matching the following template:

```
- [message-type](#message-type-section-title-in-doc)
```

For example:
```
#### Protocol Messages
* [send-schema](#send-schema)
* [schema-id](#schema-id)
...
```
In this case, the link and the link text match but the `#send-schema` is derived from the `### Send schema` header (markdown parsing on github turns headers into anchors on the web page by `to_lower`ing it and replacing spaces with hyphens)

To generate the folders after placing the `README.md` in the correct location, run:

```
make clean docs
```

From the `docs` folder.

This requires `make` and `awk` to be installed on your system. If you don't have these on your system, maintainers of this repository can take care of doc generation on your behalf.