### PR TITLE
proper regex for version check

### DIFF
--- a/src/renderer/components/CredentialIssuance/SchemaList.vue
+++ b/src/renderer/components/CredentialIssuance/SchemaList.vue
@@ -107,8 +107,9 @@ export default {
         version: [
           {
             required: true,
-            pattern: /^((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/,
-            message: "Please input a valid schema version.",
+            pattern: /^[0-9]+(?:\.[0-9]+){1,2}$/,
+            message:
+              "Versions must be a number with one or two decimals (1.0 or 1.0.0).",
             trigger: "blur",
           },
         ],


### PR DESCRIPTION
The current regular expression for schema version check is not correct. This pull request updates it to be the same one used in the indy ledger source code.

Signed-off-by: Adam Burdett <burdettadam@gmail.com>