### PR TITLE
Various fixes and improvements

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -87,6 +87,36 @@ function createWindow() {
   mainWindow.on('closed', () => {
     console.log('\nApplication exiting...')
   })
+  mainWindow.webContents.on('context-menu', (e, props) => {
+    const InputMenu = Menu.buildFromTemplate([{
+        label: 'Undo',
+        role: 'undo',
+    }, {
+        label: 'Redo',
+        role: 'redo',
+    }, {
+        type: 'separator',
+    }, {
+        label: 'Cut',
+        role: 'cut',
+    }, {
+        label: 'Copy',
+        role: 'copy',
+    }, {
+        label: 'Paste',
+        role: 'paste',
+    }, {
+        type: 'separator',
+    }, {
+        label: 'Select all',
+        role: 'selectall',
+    },
+    ]);
+    const { inputFieldType } = props;
+    if (inputFieldType === 'plainText') {
+      InputMenu.popup(mainWindow);
+    }
+  });
 }
 
 app.on('ready', () => {

--- a/src/renderer/components/AgentBase.vue
+++ b/src/renderer/components/AgentBase.vue
@@ -23,6 +23,7 @@
         :disabled="dids.length === 0">
         <el-select
           v-model="active_did"
+          no-data-text="No DIDs found"
           filterable placeholder="Activate DID">
           <el-option
             v-for="did in dids"

--- a/src/renderer/components/AgentBase.vue
+++ b/src/renderer/components/AgentBase.vue
@@ -57,7 +57,7 @@
 
 <script>
 const fs = require("fs");
-
+const electron = require('electron');
 const bs58 = require('bs58');
 const rp = require('request-promise');
 
@@ -272,6 +272,45 @@ export default {
     });
     this.$electron.ipcRenderer.on('toolbox-mediator-change', async (event, data) => {
       this.$message_bus.$emit('toolbox-mediator-change');
+    });
+    const InputMenu = electron.remote.Menu.buildFromTemplate([{
+      label: 'Undo',
+      role: 'undo',
+    }, {
+      label: 'Redo',
+      role: 'redo',
+    }, {
+      type: 'separator',
+    }, {
+      label: 'Cut',
+      role: 'cut',
+    }, {
+      label: 'Copy',
+      role: 'copy',
+    }, {
+      label: 'Paste',
+      role: 'paste',
+    }, {
+      type: 'separator',
+    }, {
+      label: 'Select all',
+      role: 'selectall',
+    },
+    ]);
+
+    document.body.addEventListener('contextmenu', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      let node = e.target;
+
+      while (node) {
+        if (node.nodeName.match(/^(input|textarea)$/i) || node.isContentEditable) {
+          InputMenu.popup(electron.remote.getCurrentWindow());
+          break;
+        }
+        node = node.parentNode;
+      }
     });
   },
   beforeDestroy: function() {

--- a/src/renderer/components/AgentList.vue
+++ b/src/renderer/components/AgentList.vue
@@ -13,21 +13,30 @@
       </div>
     </el-card>
 
-    <el-card shadow="never" class="function_card" id="new_agent_connection">
-      <span slot="header">New Agent Connection</span>
-      <div>
-        <el-form :inline="true">
-          <el-input v-model="new_agent_invitation" placeholder="Paste agent invitation"></el-input>
-          <el-button type="primary" @click="connect_clicked">Connect</el-button>
-        </el-form>
-      </div>
-      <el-alert v-show="invitation_error != ''"
-        title="Invitation Error"
-        type="error"
-        :description="invitation_error"
-        show-icon>
-      </el-alert>
-    </el-card>
+    <hr></hr>
+
+    <div class="invite-entry">
+      <h5>New Agent Connection</h5>
+      <el-form :inline="true">
+        <el-input
+          v-model="new_agent_invitation"
+          placeholder="Paste agent invitation"
+          @keypress.enter.native="connect_clicked">
+        <el-button
+          slot="append"
+          type="primary"
+          icon="el-icon-plus"
+          @click="connect_clicked"
+          >Connect</el-button>
+        </el-input>
+      </el-form>
+    </div>
+    <el-alert v-show="invitation_error != ''"
+      title="Invitation Error"
+      type="error"
+      :description="invitation_error"
+      show-icon>
+    </el-alert>
     <el-card shadow="never" class="function_card" id="new_agent_invitation" v-show="hasMediator && false">
       <span slot="header">New Agent Invitation</span>
       <div>
@@ -43,21 +52,28 @@
         show-icon>
       </el-alert>
     </el-card>
-    <el-card shadow="never" class="function_card" id="new_mediator_connection">
-      <span slot="header">Connect to Mediator</span>
-      <div>
-        <el-form :inline="true">
-          <el-input v-model="new_mediator_invitation" placeholder="Paste mediator invitation"></el-input>
-          <el-button type="primary" @click="process_mediator_invitation">Connect</el-button>
-        </el-form>
-      </div>
-      <el-alert v-show="mediation_error != ''"
-        title="Invitation Error"
-        type="error"
-        :description="mediation_error"
-        show-icon>
-      </el-alert>
-    </el-card>
+    <div class="invite-entry">
+    <h5>Connect to Mediator</h5>
+      <el-form :inline="true">
+        <el-input
+          v-model="new_mediator_invitation"
+          placeholder="Paste mediator invitation"
+          @keypress.enter.native="process_mediator_invitation">
+        <el-button
+          slot="append"
+          type="primary"
+          icon="el-icon-plus"
+          @click="process_mediator_invitation"
+          >Connect</el-button>
+        </el-input>
+      </el-form>
+    </div>
+    <el-alert v-show="mediation_error != ''"
+      title="Invitation Error"
+      type="error"
+      :description="mediation_error"
+      show-icon>
+    </el-alert>
   </el-row>
 </template>
 
@@ -439,5 +455,11 @@ export default {
     text-align: right;
     float:right;
     margin-top: 10px;
+  }
+  .invite-entry {
+    margin: 1em 1em;
+  }
+  hr {
+    margin: 1em;
   }
 </style>

--- a/src/renderer/components/AgentList.vue
+++ b/src/renderer/components/AgentList.vue
@@ -395,7 +395,7 @@ export default {
       const unpackedResponse = await didcomm.unpackMessage(res, toolbox_did);
       const response = JSON.parse(unpackedResponse.message);
       //TODO: Validate signature against invite.
-      let buff = new Buffer(response['connection~sig'].sig_data, 'base64');
+      let buff = Buffer.from(response['connection~sig'].sig_data, 'base64');
       let text = buff.toString('ascii');
       //first 8 chars are a timestamp for the signature, so we ignore those before parsing value
       response.connection = JSON.parse(text.substring(8));

--- a/src/renderer/components/AgentList.vue
+++ b/src/renderer/components/AgentList.vue
@@ -13,7 +13,7 @@
       </div>
     </el-card>
 
-    <hr></hr>
+    <hr v-if="agent_list.length > 0"></hr>
 
     <div class="invite-entry">
       <h5>New Agent Connection</h5>

--- a/src/renderer/components/ConnectionsNew/ConnectionList.vue
+++ b/src/renderer/components/ConnectionsNew/ConnectionList.vue
@@ -15,21 +15,24 @@
           :name="connection.connection_id"
           :key="connection.connection">
           <el-row :key="connection.connection">
-            <p>Connected to: {{connection.label}}</p>
-            <p>Connection ID: {{connection.connection_id}}</p>
-            <p>My DID: {{connection.my_did}}</p>
-            <p>Their DID: {{connection.their_did}}</p>
+            <ul>
+              <li><strong>Connected to:</strong> {{connection.label}} ({{connection.connection_id}})</li>
+              <li><strong>State:</strong> {{connection.state}}</li>
+              <li><strong>My DID:</strong> {{connection.my_did}}</li>
+              <li><strong>Their DID:</strong> {{connection.their_did}}</li>
+            </ul>
             <div>
               <vue-json-pretty
                 :deep=0
-                :data="connection">
+                :deepCollapseChildren="true"
+                :data="connection.raw_repr">
               </vue-json-pretty>
             </div>
             <template v-if="editable">
               <el-button @click="edit(connection)">Edit</el-button>
             </template>
             <el-button type="danger" @click="delete_conn(connection)">Delete</el-button>
-            <el-button v-on:click="collapse_expanded(connection)">^</el-button>
+            <el-button v-on:click="collapse_expanded(connection)"><i class="el-icon-arrow-up"></i></el-button>
           </el-row>
         </el-collapse-item>
       </ul>

--- a/src/renderer/components/ConnectionsNew/index.vue
+++ b/src/renderer/components/ConnectionsNew/index.vue
@@ -38,6 +38,7 @@
         <el-select style="width: 300px;"
           v-model="invite_form.mediation_id"
           filterable
+          no-data-text="No mediators found"
           placeholder="Mediator">
           <el-option
             v-for="mediator in mediators"

--- a/src/renderer/components/ConnectionsNew/index.vue
+++ b/src/renderer/components/ConnectionsNew/index.vue
@@ -26,7 +26,8 @@
         label="Invitation URL:">
         <el-input
           style="width: 300px;"
-          v-model="invite_form.invitation">
+          v-model="invite_form.invitation"
+          @keypress.enter.native="recieve_invitation">
           <el-button
             slot="append"
             type="primary"
@@ -113,7 +114,10 @@ export const shared = {
     [metadata.types.deleted]:
     (share, msg) => share.fetch_connections(),
     [metadata.types.connected]:
-    (share, msg) => share.fetch_connections(),
+    (share, msg) => {
+      share.fetch_connections();
+      share.fetch_invitations_v1();
+    },
   },
   methods: {
     fetch_connections: ({send}) => {

--- a/src/renderer/components/CredentialIssuance/Attributes.vue
+++ b/src/renderer/components/CredentialIssuance/Attributes.vue
@@ -1,0 +1,28 @@
+<template>
+  <div v-if="!inline && !values">
+    {{joined}}
+  </div>
+  <span v-else-if="!values">
+    {{joined}}
+  </span>
+  <div v-else-if="!inline && values">
+    <ul>
+      <li v-for="value in values" :key="value.name"><strong>{{value.name}}:</strong> {{value.value}}</li>
+    </ul>
+  </div>
+</template>
+<script>
+export default {
+  name: "attributes",
+  props: {
+    list: Array,
+    values: Array,
+    inline: Boolean,
+  },
+  computed: {
+    joined: function() {
+      return this.list.join(', ')
+    }
+  }
+}
+</script>

--- a/src/renderer/components/CredentialIssuance/CredDefList.vue
+++ b/src/renderer/components/CredentialIssuance/CredDefList.vue
@@ -52,6 +52,7 @@
           <el-select
             v-model="createForm.schema_id"
             filterable
+            no-data-text="No schemas found"
             value-key="createForm.schema_id"
             placeholder="Select">
             <el-option

--- a/src/renderer/components/CredentialIssuance/CredDefList.vue
+++ b/src/renderer/components/CredentialIssuance/CredDefList.vue
@@ -29,12 +29,15 @@
           :name="creddef.cred_def_id"
           :key="creddef.cred_def">
           <el-row :key="creddef.cred_def">
-            <p>Cred. def. ID: {{creddef.cred_def_id}}</p>
-            <p>Schema ID: {{creddef.schema_id}}</p>
-            <p>Created: {{creddef.created_at}}</p>
+            <ul>
+              <li><strong>Schema ID:</strong> {{creddef.schema_id}}</li>
+              <li><strong>Created:</strong> {{creddef.created_at}}</li>
+              <li><strong>Attributes:</strong> <attributes :list="creddef.attributes" inline></attributes></li>
+            </ul>
             <div>
               <vue-json-pretty
                 :deep=0
+                :deepCollapseChildren="true"
                 :data="creddef">
               </vue-json-pretty>
             </div>
@@ -72,6 +75,7 @@
 import VueJsonPretty from 'vue-json-pretty';
 import message_bus from '../../message_bus.js';
 import share from '../../share.js';
+import Attributes from './Attributes.vue';
 
 export default {
   name: 'cred-def-list',
@@ -99,6 +103,7 @@ export default {
   ],
   components: {
     VueJsonPretty,
+    Attributes,
   },
   data () {
     return {

--- a/src/renderer/components/CredentialIssuance/IssuedCredList.vue
+++ b/src/renderer/components/CredentialIssuance/IssuedCredList.vue
@@ -49,6 +49,7 @@
           <el-select
             v-model="issueForm.connection_id"
             filterable
+            no-data-text="No connections found"
             value-key="issueForm.connection_id"
             placeholder="Select">
             <el-option
@@ -62,6 +63,7 @@
         <el-form-item label="Credential Definition:" :label-width="formLabelWidth">
           <el-select
             v-model="issueForm.selected_cred_def"
+            no-data-text="No credential definitions found"
             remote
             value-key="issueForm.selected_cred_def"
             placeholder="Select"

--- a/src/renderer/components/CredentialIssuance/IssuedCredList.vue
+++ b/src/renderer/components/CredentialIssuance/IssuedCredList.vue
@@ -18,6 +18,10 @@
           v-bind:title="credential_title(issued_credential)"
           :name="issued_credential.credential_exchange_id"
           :key="issued_credential.issued_credential">
+          <template slot="title">
+            <i :class="issued_credential.state === 'credential_acked' ? 'el-icon-finished status' : 'el-icon-loading status'"></i>
+            {{credential_title(issued_credential)}}
+          </template>
           <el-row :key="issued_credential.issued_credential">
             <ul>
               <li><strong>Issued to:</strong> {{issued_credential.connection.label}} ({{issued_credential.connection.connection_id}})</li>
@@ -97,6 +101,10 @@
 <style>
 .issued-attrs {
   margin-left: 2em;
+}
+.status {
+  font-size: 1.5em;
+  margin-right: .25em;
 }
 </style>
 <script>

--- a/src/renderer/components/CredentialIssuance/IssuedCredList.vue
+++ b/src/renderer/components/CredentialIssuance/IssuedCredList.vue
@@ -19,13 +19,18 @@
           :name="issued_credential.credential_exchange_id"
           :key="issued_credential.issued_credential">
           <el-row :key="issued_credential.issued_credential">
-            <p>Name: {{issued_credential.name}}</p>
-            <p>Cred. def. ID: {{issued_credential.cred_def_id}}</p>
-            <p>Created: {{issued_credential.created_at}}</p>
-            <p>Issued to: {{issued_credential.connection_their_label}}</p>
+            <ul>
+              <li><strong>Issued to:</strong> {{issued_credential.connection.label}} ({{issued_credential.connection.connection_id}})</li>
+              <li><strong>State:</strong> {{issued_credential.state}}</li>
+              <li><strong>Credential Definition ID:</strong> {{issued_credential.credential_definition_id}}</li>
+              <li><strong>Schema ID:</strong> {{issued_credential.schema_id}}</li>
+              <li><strong>Created:</strong> {{issued_credential.created_at}}</li>
+              <li><strong>Attributes:</strong> <attributes class="issued-attrs" :values="issued_credential.credential_proposal_dict.credential_proposal.attributes"></attributes></li>
+            </ul>
             <div>
               <vue-json-pretty
                 :deep=0
+                :deepCollapseChildren="true"
                 :data="issued_credential">
               </vue-json-pretty>
             </div>
@@ -89,10 +94,15 @@
     </el-dialog>
   </div>
 </template>
-
+<style>
+.issued-attrs {
+  margin-left: 2em;
+}
+</style>
 <script>
 import VueJsonPretty from 'vue-json-pretty';
 import share from '@/share.js';
+import Attributes from './Attributes.vue';
 
 export default {
   name: 'issued-cred-list',
@@ -100,6 +110,7 @@ export default {
   mixins: [share({use: ['id_to_connection']})],
   components: {
     VueJsonPretty,
+    Attributes,
   },
   data () {
     return {

--- a/src/renderer/components/CredentialIssuance/SchemaList.vue
+++ b/src/renderer/components/CredentialIssuance/SchemaList.vue
@@ -28,12 +28,19 @@
           :key="schema.schema"
         >
           <el-row :key="schema.schema">
-            <p>Name: {{schema.schema_name}}</p>
-            <p>Version: {{schema.schema_version}}</p>
-            <p>Schema ID: {{schema.schema_id}}</p>
-            <p>Created: {{schema.created_at}}</p>
+            <ul>
+              <li><strong>Name:</strong> {{schema.schema_name}}</li>
+              <li><strong>Version:</strong> {{schema.schema_version}}</li>
+              <li><strong>Schema ID:</strong> {{schema.schema_id}}</li>
+              <li><strong>Created:</strong> {{schema.created_at}}</li>
+              <li><strong>Attributes:</strong><attributes :list="schema.attributes" inline></attributes></li>
+            </ul>
             <div>
-              <vue-json-pretty :deep="0" :data="schema"> </vue-json-pretty>
+              <vue-json-pretty
+                :deep="0"
+                :deepCollapseChildren="true"
+                :data="schema"
+              ></vue-json-pretty>
             </div>
             <el-button v-on:click="collapse_expanded(schema)">^</el-button>
           </el-row>
@@ -83,12 +90,14 @@
 
 <script>
 import VueJsonPretty from "vue-json-pretty";
+import Attributes from "./Attributes.vue";
 
 export default {
   name: "schema-list",
   props: ["title", "list", "editable"],
   components: {
     VueJsonPretty,
+    Attributes,
   },
   data() {
     return {

--- a/src/renderer/components/InvitationsNew/index.vue
+++ b/src/renderer/components/InvitationsNew/index.vue
@@ -64,6 +64,7 @@
         <el-select style="width: 200px;"
           v-model="invite_form.mediation_id"
           filterable
+          no-data-text="No mediators found"
           placeholder="Mediator">
           <el-option
             v-for="mediator in mediators"

--- a/src/renderer/components/Messages/index.vue
+++ b/src/renderer/components/Messages/index.vue
@@ -5,6 +5,7 @@
         <el-select
           v-model="connection_id"
           filterable
+          no-data-text="No connections found"
           placeholder="Select Conversation"
           @change="connection_selected">
           <el-option

--- a/src/renderer/components/MyCredentials/MyCredentialsList.vue
+++ b/src/renderer/components/MyCredentials/MyCredentialsList.vue
@@ -19,6 +19,18 @@
           :name="credential.cred_def_id"
           :key="credential.cred_def_id">
           <el-row>
+            <ul>
+              <li><strong>State:</strong> {{credential.state}}</li>
+              <li><strong>Credential Definition ID:</strong> {{credential.credential_definition_id}}</li>
+              <li><strong>Schema ID:</strong> {{credential.credential.schema_id}}</li>
+              <li><strong>Created:</strong> {{credential.created_at}}</li>
+              <li><strong>Attributes:</strong>
+                <attributes
+                  class="received-attrs"
+                  :values="Object.keys(credential.credential.attrs).map(item => ({name: item, value: credential.credential.attrs[item]}))"
+                ></attributes>
+              </li>
+            </ul>
             <div>
               <vue-json-pretty
                 :deep=1
@@ -114,10 +126,15 @@
     </el-dialog>
   </div>
 </template>
-
+<style>
+.received-attrs {
+  margin-left: 2em;
+}
+</style>
 <script>
 import VueJsonPretty from 'vue-json-pretty';
 import share from '@/share.js';
+import Attributes from '../CredentialIssuance/Attributes.vue';
 
 export default {
   name: 'my-credentials-list',
@@ -131,6 +148,7 @@ export default {
   mixins: [share({use: ['id_to_connection']})],
   components: {
     VueJsonPretty,
+    Attributes,
   },
   data () {
     return {

--- a/src/renderer/components/MyCredentials/MyCredentialsList.vue
+++ b/src/renderer/components/MyCredentials/MyCredentialsList.vue
@@ -51,6 +51,7 @@
           <el-select
             v-model="proposalForm.connection_id"
             filterable
+            no-data-text="No connections found"
             value-key="proposalForm.connection_id"
             placeholder="Select">
             <el-option

--- a/src/renderer/components/MyCredentials/MyCredentialsList.vue
+++ b/src/renderer/components/MyCredentials/MyCredentialsList.vue
@@ -15,9 +15,12 @@
       <ul class="list">
         <el-collapse-item
           v-for="credential in credentials"
-          v-bind:title="credential_title(credential)"
           :name="credential.cred_def_id"
           :key="credential.cred_def_id">
+          <template slot="title">
+            <i :class="credential.state === 'credential_acked' ? 'el-icon-finished status' : 'el-icon-loading status'"></i>
+            {{credential_title(credential)}}
+          </template>
           <el-row>
             <ul>
               <li><strong>State:</strong> {{credential.state}}</li>
@@ -33,45 +36,16 @@
             </ul>
             <div>
               <vue-json-pretty
-                :deep=1
+                :deep=0
+                :deepCollapseChildren="true"
                 :data="credential">
               </vue-json-pretty>
             </div>
-            <el-button v-on:click="collapse_expanded(credential)">^</el-button>
           </el-row>
         </el-collapse-item>
       </ul>
     </el-collapse>
-    <nav
-      v-if="offerReceivedStateCredentials.length"
-      class="navbar navbar-expand-lg navbar-light bg-light">
-      <a class="navbar-brand" href="#">Offers</a>
-      <!-- <el-button
-        type="primary"
-        icon="el-icon-plus"
-        @click="offerFormActive = true">Accept Offer</el-button> -->
-    </nav>
-    <el-collapse
-      v-model="expanded_items">
-      <ul class="list">
-        <el-collapse-item
-          v-for="credential in offerReceivedStateCredentials"
-          v-bind:title="credential.credential_exchange_id"
-          :name="credential.credential_exchange_id"
-          :key="credential.credential_exchange_id">
-          <el-row>
-            <div>
-              <vue-json-pretty
-                :deep=1
-                :data="credential">
-              </vue-json-pretty>
-            </div>
-            <el-button v-on:click="collapse_expanded(credential)">^</el-button>
-          </el-row>
-        </el-collapse-item>
-      </ul>
-    </el-collapse>
-    <el-dialog title="Propose Credential" :visible.sync="proposalFormActive" @close="deActivateForm()">
+    <el-dialog title="Propose Credential" :visible.sync="proposalFormActive" @close="deactivateForm()">
       <el-form :model="proposalForm">
         <el-form-item label="Connection:" :label-width="formLabelWidth">
           <el-select

--- a/src/renderer/components/MyCredentials/MyCredentialsList.vue
+++ b/src/renderer/components/MyCredentials/MyCredentialsList.vue
@@ -68,7 +68,8 @@
             value-key="proposalForm.selected_cred_def"
             placeholder="Select"
             :disabled="!proposalForm.connection_id"
-            @change="update_attributes">
+            @change="update_attributes"
+            no-data-text="No credential definitions found">
             <el-option
               v-for="cred_def in cred_defs"
               :key="cred_def.cred_def_id"
@@ -94,7 +95,7 @@
         </el-form-item>
       </el-form>
       <span slot="footer" class="dialog-footer">
-        <el-button @click="deActivateForm()">Cancel</el-button>
+        <el-button @click="deactivateForm()">Cancel</el-button>
         <el-button :disabled="!proposalForm.selected_cred_def" type="primary" @click="propose">Confirm</el-button>
       </span>
     </el-dialog>
@@ -138,12 +139,7 @@ export default {
     }
   },
   methods: {
-    collapse_expanded: function(credential){
-      this.expanded_items = this.expanded_items.filter(
-        item => item != credential.credential_exchange_id
-      );
-    },
-    deActivateForm: function() {
+    deactivateForm: function() {
       this.proposalFormActive = false;
       this.proposalForm = {
         connection_id: '',
@@ -198,24 +194,6 @@ export default {
         }
         return item;
       });
-    },
-    offerReceivedStateCredentials(){
-      return this.credentials.filter(cred => "state" in cred && cred.state === "offer_received")
-    },
-    sentRequestStateCredentials(){
-      return this.credentials.filter(cred => "state" in cred && cred.state === "request_sent")
-    },
-    receivedStateCredentials(){
-      return this.credentials.filter(
-        cred =>
-          "state" in cred &&
-          cred.state === "credential_received" ||
-          cred.state === "stored" ||
-          cred.state === "credential_acked"
-      )
-    },
-    storedStateCredentials(){
-      return this.credentials.filter(cred => "state" in cred && cred.state === "stored")
     },
   }
 }

--- a/src/renderer/components/Presentations/Presentation.vue
+++ b/src/renderer/components/Presentations/Presentation.vue
@@ -45,6 +45,7 @@
         <el-form-item label="Connection:" :label-width="formLabelWidth">
           <el-select
             v-model="proposalForm.connection_id"
+            no-data-text="No connections found"
             filterable
             placeholder="Connection">
             <el-option
@@ -87,6 +88,7 @@
             placeholder="Attribute Value">
             <el-select
               slot="prepend"
+              no-data-text="No attributes found"
               v-if="proposalForm.attributes[index].cred_def != null"
               v-model="proposalForm.attributes[index].name"
               placeholder="Attribute Name"
@@ -130,6 +132,7 @@
             placeholder="Threshold">
             <el-select
               slot="prepend"
+              no-data-text="No attributes found"
               v-if="proposalForm.predicates[index].cred_def != null"
               v-model="proposalForm.predicates[index].name"
               placeholder="Attribute Name"

--- a/src/renderer/components/Presentations/Presentation.vue
+++ b/src/renderer/components/Presentations/Presentation.vue
@@ -27,8 +27,8 @@
               <li><strong>Requested by:</strong> {{connection_details[presentation.connection_id].label}} ({{presentation.connection_id}})</li>
               <li><strong>State:</strong> {{presentation.state}}</li>
               <li><strong>Presentation Exchange ID:</strong> {{presentation.presentation_exchange_id}}</li>
-              <li><strong>Requested Attributes:</strong> <attributes :list="Object.keys(presentation.presentation_request.requested_attributes)" inline></attributes></li>
-              <li><strong>Requested Predicates:</strong> <attributes :list="Object.keys(presentation.presentation_request.requested_predicates)" inline></attributes></li>
+              <li><strong>Requested Attributes:</strong> <attributes :list="requestedAttributes(presentation)" inline></attributes></li>
+              <li><strong>Requested Predicates:</strong> <attributes :list="requestedPredicates(presentation)" inline></attributes></li>
             </ul>
             <div>
               <vue-json-pretty
@@ -287,6 +287,14 @@ export default {
         });
       });
     },
+    requestedAttributes: function(presentation) {
+      let attrs = presentation.presentation_request.requested_attributes
+      return Object.values(attrs).map(attr => attr.name)
+    },
+    requestedPredicates: function(presentation) {
+      let preds = presentation.presentation_request.requested_predicates
+      return Object.values(preds).map(pred => `${pred.name} ${pred.p_type} ${pred.p_value}`)
+    }
   },
   computed: {
     connection_map: function() {

--- a/src/renderer/components/Presentations/Presentation.vue
+++ b/src/renderer/components/Presentations/Presentation.vue
@@ -14,105 +14,32 @@
     <el-collapse v-model="ver_pres_expanded_items">
       <ul class="list">
         <el-collapse-item
-          v-for="presentation in VerifiedPresentations"
-          v-bind:title="presentation_title(presentation)"
+          v-for="presentation in presentations"
           :name="presentation.presentation_exchange_id"
           :key="presentation.presentation">
+          <template slot="title">
+            <i :class="presentation.state === 'presentation_acked' ? 'el-icon-finished status' : 'el-icon-loading status'"></i>
+            {{presentation_title(presentation)}}
+          </template>
           <el-row :key="presentation.presentation">
-            <p>Connected to: {{connection_details[presentation.connection_id].label}}</p>
-            <p>Presentation Exchange ID: {{presentation.presentation_exchange_id}}</p>
-            <p>Connection ID: {{presentation.connection_id}}</p>
-            <p>Role: {{presentation.role}}</p>
+            <ul>
+              <li><strong>Requested by:</strong> {{connection_details[presentation.connection_id].label}} ({{presentation.connection_id}})</li>
+              <li><strong>State:</strong> {{presentation.state}}</li>
+              <li><strong>Presentation Exchange ID:</strong> {{presentation.presentation_exchange_id}}</li>
+              <li><strong>Requested Attributes:</strong> <attributes :list="Object.keys(presentation.presentation_request.requested_attributes)" inline></attributes></li>
+              <li><strong>Requested Predicates:</strong> <attributes :list="Object.keys(presentation.presentation_request.requested_predicates)" inline></attributes></li>
+            </ul>
             <div>
               <vue-json-pretty
                 :deep=0
+                :deepCollapseChildren="true"
                 :data="presentation">
               </vue-json-pretty>
             </div>
-            <el-button v-on:click="collapse_expanded_ver_pres(presentation)">^</el-button>
           </el-row>
         </el-collapse-item>
       </ul>
     </el-collapse>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-      <a class="navbar-brand" href="#"> Received Requests </a>
-    </nav>
-    <el-collapse v-model="rec_req_expanded_items">
-      <ul class="list">
-        <el-collapse-item
-          v-for="presentation in ReceivedRequests"
-          v-bind:title="presentation_title(presentation)"
-          :name="presentation.presentation_exchange_id"
-          :key="presentation.presentation">
-          <el-row :key="presentation.presentation">
-            <p>Connected to: {{connection_details[presentation.connection_id].label}}</p>
-            <p>Presentation Exchange ID: {{presentation.presentation_exchange_id}}</p>
-            <p>Connection ID: {{presentation.connection_id}}</p>
-            <p>Role: {{presentation.role}}</p>
-            <div>
-              <vue-json-pretty
-                :deep=0
-                :data="presentation">
-              </vue-json-pretty>
-            </div>
-            <el-button v-on:click="collapse_expanded_rec_req(presentation)">^</el-button>
-          </el-row>
-        </el-collapse-item>
-      </ul>
-    </el-collapse>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-      <a class="navbar-brand" href="#"> Sent Presentation </a>
-    </nav>
-    <el-collapse v-model="sent_pres_expanded_items">
-      <ul class="list">
-        <el-collapse-item
-          v-for="presentation in SentPresentations"
-          v-bind:title="presentation_title(presentation)"
-          :name="presentation.presentation_exchange_id"
-          :key="presentation.presentation">
-          <el-row :key="presentation.presentation">
-            <p>Connected to: {{connection_details[presentation.connection_id].label}}</p>
-            <p>Presentation Exchange ID: {{presentation.presentation_exchange_id}}</p>
-            <p>Connection ID: {{presentation.connection_id}}</p>
-            <p>Role: {{presentation.role}}</p>
-            <div>
-              <vue-json-pretty
-                :deep=0
-                :data="presentation">
-              </vue-json-pretty>
-            </div>
-            <el-button v-on:click="collapse_expanded_sent_pres(presentation)">^</el-button>
-          </el-row>
-        </el-collapse-item>
-      </ul>
-    </el-collapse>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-      <a class="navbar-brand" href="#"> Sent Proposals </a>
-    </nav>
-    <el-collapse v-model="sent_prop_expanded_items">
-      <ul class="list">
-        <el-collapse-item
-          v-for="presentation in SentProposals"
-          v-bind:title="presentation_title(presentation)"
-          :name="presentation.presentation_exchange_id"
-          :key="presentation.presentation">
-          <el-row :key="presentation.presentation">
-            <p>Connected to: {{connection_details[presentation.connection_id].label}}</p>
-            <p>Presentation Exchange ID: {{presentation.presentation_exchange_id}}</p>
-            <p>Connection ID: {{presentation.connection_id}}</p>
-            <p>Role: {{presentation.role}}</p>
-            <div>
-              <vue-json-pretty
-                :deep=0
-                :data="presentation">
-              </vue-json-pretty>
-            </div>
-            <el-button v-on:click="collapse_expanded_sent_prop(presentation)">^</el-button>
-          </el-row>
-        </el-collapse-item>
-      </ul>
-    </el-collapse>
-
     <el-dialog title="Make a Presentation Proposal" :visible.sync="proposalFormActive">
       <el-form :model="proposalForm">
         <el-form-item label="Connection:" :label-width="formLabelWidth">
@@ -249,8 +176,16 @@
   </div>
 </template>
 
+<style>
+i.status {
+  font-size: 1.5em;
+  margin-right: .25em;
+}
+</style>
+
 <script>
 import VueJsonPretty from 'vue-json-pretty';
+import Attributes from '../CredentialIssuance/Attributes.vue';
 
 export default {
   name: 'presentation',
@@ -263,6 +198,7 @@ export default {
   ],
   components: {
     VueJsonPretty,
+    Attributes,
   },
   data () {
     return {
@@ -306,7 +242,7 @@ export default {
       let connection = this.connection_details[pres.connection_id];
       let title= "";
       if (connection && connection.label) {
-        title += `Sent to ${connection.label}`
+        title += `Requested by ${connection.label}`
       } else {
         title += 'Unknown'
       }
@@ -338,26 +274,6 @@ export default {
     remove_predicate: function(index) {
       this.proposalForm.predicates.splice(index, 1);
     },
-    collapse_expanded_ver_pres: function(presentation){
-      this.ver_pres_expanded_items = this.ver_pres_expanded_items.filter(
-        item => item != presentation.presentation_exchange_id
-      );
-    },
-    collapse_expanded_sent_prop: function(presentation){
-      this.sent_prop_expanded_items = this.sent_prop_expanded_items.filter(
-        item => item != presentation.presentation_exchange_id
-      );
-    },
-    collapse_expanded_rec_req: function(presentation){
-      this.rec_req_expanded_items = this.rec_req_expanded_items.filter(
-        item => item != presentation.presentation_exchange_id
-      );
-    },
-    collapse_expanded_sent_pres: function(presentation){
-      this.sent_pres_expanded_items = this.sent_pres_expanded_items.filter(
-        item => item != presentation.presentation_exchange_id
-      );
-    },
     update_attributes: function(cred_def) {
       var comp = this;
       cred_def.attributes.forEach(name => {
@@ -380,49 +296,6 @@ export default {
     completed_verifications: function() {
       return this.presentations.filter(pres_exch => pres_exch.state === 'verified');
     },
-    VerifiedPresentations() {
-      console.log('PRESENTATIONS', this.presentations);
-      return this.presentations.filter(
-        exchange =>
-        (
-          "state" in exchange &&
-          (
-            exchange.state === "verified" ||
-            exchange.state === "presentation_acked"
-          )
-        ) &&
-        //==========================================
-        "role" in exchange &&
-        "prover" === exchange.role )
-    },
-    ReceivedRequests(){
-      return this.presentations.filter(
-        exchange =>
-        "state" in exchange &&
-        exchange.state === "request_received" &&
-        //==========================================
-        "role" in exchange &&
-        "prover" === exchange.role)
-    },
-    SentPresentations(){
-      return this.presentations.filter(
-        exchange =>
-        "state" in exchange &&
-        exchange.state === "presentation_sent" &&
-        //==========================================
-        "role" in exchange &&
-        "prover" === exchange.role )
-    },
-    SentProposals(){
-      return this.presentations.filter(
-        exchange =>
-        "state" in exchange &&
-        exchange.state === "proposal_sent"  &&
-        //==========================================
-        "role" in exchange &&
-        "prover" === exchange.role
-      )
-    }
   }
 }
 </script>

--- a/src/renderer/components/Presentations/Presentation.vue
+++ b/src/renderer/components/Presentations/Presentation.vue
@@ -5,6 +5,7 @@
       <el-button
         type="primary"
         icon="el-icon-plus"
+        disabled
         @click="proposalFormActive = true">Presentation Proposal</el-button>
       <el-button
         type="primary"

--- a/src/renderer/components/Routing/index.vue
+++ b/src/renderer/components/Routing/index.vue
@@ -58,6 +58,7 @@
         <el-select
           v-model="request_mediation_form.connection_id"
           filterable
+          no-data-text="No connections found"
           placeholder="Potential mediator...">
           <el-option
             v-for="connection in active_connections"
@@ -78,6 +79,7 @@
         <el-select
           v-model="updaterouteform.connection_id"
           filterable
+          no-data-text="No connections found"
           placeholder="Connection">
           <el-option
             v-for="connection in active_connections"
@@ -92,6 +94,7 @@
           v-model="updaterouteform.did"
           value-key="did.did"
           filterable
+          no-data-text="No DIDs found"
           placeholder="DID">
           <el-option
             v-for="did in dids"

--- a/src/renderer/components/Verifications/Verification.vue
+++ b/src/renderer/components/Verifications/Verification.vue
@@ -13,28 +13,30 @@
         @click="$emit('verification-refresh',)"></el-button>
     </nav>
     <el-collapse v-model="expanded_items">
-      <ul class="list">
         <el-collapse-item
           v-for="presentation in presentations"
-          v-bind:title="presentation_title(presentation)"
           :name="presentation.presentation_exchange_id"
           :key="presentation.presentation">
+          <template slot="title">
+            <i v-bind:class="presentation.verified ? 'el-icon-success verified' : 'el-icon-circle-close verified'"></i> {{presentation_title(presentation)}}
+          </template>
           <el-row :key="presentation.presentation">
-            <p>Sent to: {{presentation.connection_their_label}}</p>
-            <p>Created at: {{presentation.created_at}}</p>
-            <p>Role: {{presentation.role}}</p>
-            <p>Connection ID: {{presentation.connection_id}}</p>
-            <p>Presentation Exchange ID: {{presentation.presentation_exchange_id}}</p>
+            <ul>
+              <li><strong>Requested from:</strong> {{presentation.connection_their_label}} ({{presentation.connection_id}})</li>
+              <li><strong>Presentation Exchange ID:</strong> {{presentation.presentation_exchange_id}}</li>
+              <li><strong>State:</strong> {{presentation.state}}</li>
+              <li><strong>Verified:</strong> {{presentation.verified ? presentation.verified : false}}</li>
+              <li><strong>Created at:</strong> {{presentation.created_at}}</li>
+            </ul>
             <div>
               <vue-json-pretty
-                :deep=0
+                :deep=2
                 :data="presentation">
               </vue-json-pretty>
             </div>
             <el-button v-on:click="collapse_expanded(presentation)">^</el-button>
           </el-row>
         </el-collapse-item>
-      </ul>
     </el-collapse>
     <el-dialog title="Request Presentation" :visible.sync="requestFormActive">
       <el-form :model="requestForm">
@@ -179,6 +181,10 @@
 }
 .restrictions .el-select {
   margin-bottom: .5em;
+}
+i.verified {
+  margin-right: .25em;
+  font-size: 1.5em;
 }
 </style>
 

--- a/src/renderer/components/Verifications/Verification.vue
+++ b/src/renderer/components/Verifications/Verification.vue
@@ -16,17 +16,19 @@
         <el-collapse-item
           v-for="presentation in presentations"
           :name="presentation.presentation_exchange_id"
-          :key="presentation.presentation">
+          :key="presentation.presentation_exchange_id">
           <template slot="title">
             <i v-bind:class="presentation.verified ? 'el-icon-success verified' : 'el-icon-circle-close verified'"></i> {{presentation_title(presentation)}}
           </template>
-          <el-row :key="presentation.presentation">
+          <el-row>
             <ul>
               <li><strong>Requested from:</strong> {{presentation.connection_their_label}} ({{presentation.connection_id}})</li>
               <li><strong>Presentation Exchange ID:</strong> {{presentation.presentation_exchange_id}}</li>
               <li><strong>State:</strong> {{presentation.state}}</li>
               <li><strong>Verified:</strong> {{presentation.verified ? presentation.verified : false}}</li>
               <li><strong>Created at:</strong> {{presentation.created_at}}</li>
+              <li v-if="presentation.presentation"><strong>Revealed Attributes:</strong> <attributes class="attributes" :values="revealedAttributes(presentation)"></attributes></li>
+              <li v-if="presentation.presentation"><strong>Predicates:</strong> <attributes :list="predicates(presentation)" inline></attributes></li>
             </ul>
             <div>
               <vue-json-pretty
@@ -186,10 +188,14 @@ i.verified {
   margin-right: .25em;
   font-size: 1.5em;
 }
+.attributes {
+  margin-left: 2em;
+}
 </style>
 
 <script>
 import VueJsonPretty from 'vue-json-pretty';
+import Attributes from '../CredentialIssuance/Attributes.vue';
 import share from '@/share.js';
 
 export default {
@@ -204,6 +210,7 @@ export default {
   mixins: [share({use: ['id_to_connection']})],
   components: {
     VueJsonPretty,
+    Attributes,
   },
   data () {
     return {
@@ -333,6 +340,14 @@ export default {
     },
     remove_predicate: function(index) {
       this.requestForm.predicates.splice(index, 1);
+    },
+    revealedAttributes: function(presentation) {
+      const attrs = presentation.presentation.requested_proof.revealed_attrs;
+      return Object.keys(attrs).map(attr => ({name: attr, value: attrs[attr].raw}))
+    },
+    predicates: function(presentation) {
+      let preds = presentation.presentation_request.requested_predicates
+      return Object.values(preds).map(pred => `${pred.name} ${pred.p_type} ${pred.p_value}`)
     }
   }
 }

--- a/src/renderer/components/Verifications/index.vue
+++ b/src/renderer/components/Verifications/index.vue
@@ -72,6 +72,9 @@ export default {
       actions: ['fetch_issuer_presentations']
     })
   ],
+  created: async function() {
+    this.fetch_issuer_presentations();
+  },
   methods: {
     async presentation_request(form){
       // response comes back in admin-issuer/0.1/presentation-exchange


### PR DESCRIPTION
Fixes:

- Improved formatting on various data summaries
- Presentations are now auto loaded on entering verification section
- Added status icons to credentials and presentations
  - Enabled removal of listings that were grouped by status. Now, each item is all in one list but status is indicated. This significantly simplified code in a few places.
- Make sure select inputs have English "no data" warnings instead of Chinese
- Add context menus (enables copy/paste through right clicks)
- Disable presentation proposal (which is not currently functional)
- Visual improvements for Agent List window
- Use enter key for triggering form actions where it makes sense