### PR TITLE
chore: update encryption envelope to 1.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "bulma-fluent": "^0.4.3",
         "dompurify": "^2.3.5",
         "element-ui": "^2.15.6",
-        "encryption-envelope-js": "^1.2.4",
+        "encryption-envelope-js": "^1.2.5",
         "marked": "^4.0.12",
         "material-design-icons": "^3.0.1",
         "request-promise": "^4.2.6",
@@ -6610,9 +6610,9 @@
       }
     },
     "node_modules/encryption-envelope-js": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/encryption-envelope-js/-/encryption-envelope-js-1.2.4.tgz",
-      "integrity": "sha512-et2uDvi2hTKb+MFkJGZTbJraWkO/Z3U5GmFeZovKuL9F5YVUvdMSQTvatucoi0vcD1ALIBZ4Kc+2uC2DznApAQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/encryption-envelope-js/-/encryption-envelope-js-1.2.5.tgz",
+      "integrity": "sha512-QjIuFou3vZTqRhn24rOvLHeKd8Q6ZBkd8crnQDWkJPNCsKAVlv4bMmHDOIhVD/Px4TFFJZsnTEvPRH1QdXOXTg==",
       "dependencies": {
         "@types/libsodium-wrappers": "^0.7.5",
         "base-58": "0.0.1",
@@ -21101,9 +21101,9 @@
       "devOptional": true
     },
     "encryption-envelope-js": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/encryption-envelope-js/-/encryption-envelope-js-1.2.4.tgz",
-      "integrity": "sha512-et2uDvi2hTKb+MFkJGZTbJraWkO/Z3U5GmFeZovKuL9F5YVUvdMSQTvatucoi0vcD1ALIBZ4Kc+2uC2DznApAQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/encryption-envelope-js/-/encryption-envelope-js-1.2.5.tgz",
+      "integrity": "sha512-QjIuFou3vZTqRhn24rOvLHeKd8Q6ZBkd8crnQDWkJPNCsKAVlv4bMmHDOIhVD/Px4TFFJZsnTEvPRH1QdXOXTg==",
       "requires": {
         "@types/libsodium-wrappers": "^0.7.5",
         "base-58": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bulma-fluent": "^0.4.3",
     "dompurify": "^2.3.5",
     "element-ui": "^2.15.6",
-    "encryption-envelope-js": "^1.2.4",
+    "encryption-envelope-js": "^1.2.5",
     "marked": "^4.0.12",
     "material-design-icons": "^3.0.1",
     "request-promise": "^4.2.6",


### PR DESCRIPTION
This targets a new release of `encryption-envelope.js` that contains fixes for some encoding issues we had previously.
Signed-off-by: Micah Peltier <micah6_8@yahoo.com>